### PR TITLE
Wrap StatsUpload in Database Transaction

### DIFF
--- a/Database/FoldingCoinStoredProceduresV1.sql
+++ b/Database/FoldingCoinStoredProceduresV1.sql
@@ -248,7 +248,7 @@ BEGIN
 
 	BEGIN TRY
 		BEGIN TRANSACTION
-			SELECT @FileDownloadErrorStatusId = FoldingCoin.GetfileDownloadErrorStatusId();
+			SELECT @FileDownloadErrorStatusId = [FoldingCoin].GetFileDownloadErrorStatusId();
 
 			UPDATE [FoldingCoin].[Downloads] 
 			SET StatusId = @FileDownloadErrorStatusId

--- a/StatsDownload/StatsDownload.Core.Interfaces/IDatabaseConnectionService.cs
+++ b/StatsDownload/StatsDownload.Core.Interfaces/IDatabaseConnectionService.cs
@@ -25,6 +25,9 @@
 
         int ExecuteStoredProcedure(string storedProcedure, IEnumerable<DbParameter> parameters);
 
+        int ExecuteStoredProcedure(DbTransaction transaction, string storedProcedure,
+            IEnumerable<DbParameter> parameters);
+
         int ExecuteStoredProcedure(string storedProcedure);
 
         void Open();

--- a/StatsDownload/StatsDownload.Core.Interfaces/IDatabaseConnectionService.cs
+++ b/StatsDownload/StatsDownload.Core.Interfaces/IDatabaseConnectionService.cs
@@ -9,13 +9,15 @@
     {
         ConnectionState ConnectionState { get; }
 
-        DbCommand CreateDbCommand();
+        void Close();
 
-        DbTransaction CreateTransaction();
+        DbCommand CreateDbCommand();
 
         DbParameter CreateParameter(string parameterName, DbType dbType, ParameterDirection direction);
 
         DbParameter CreateParameter(string parameterName, DbType dbType, ParameterDirection direction, int size);
+
+        DbTransaction CreateTransaction();
 
         DbDataReader ExecuteReader(string commandText);
 
@@ -26,7 +28,5 @@
         int ExecuteStoredProcedure(string storedProcedure);
 
         void Open();
-
-        void Close();
     }
 }

--- a/StatsDownload/StatsDownload.Core.Interfaces/IDatabaseConnectionService.cs
+++ b/StatsDownload/StatsDownload.Core.Interfaces/IDatabaseConnectionService.cs
@@ -26,5 +26,7 @@
         int ExecuteStoredProcedure(string storedProcedure);
 
         void Open();
+
+        void Close();
     }
 }

--- a/StatsDownload/StatsDownload.Core.Interfaces/IStatsUploadDatabaseService.cs
+++ b/StatsDownload/StatsDownload.Core.Interfaces/IStatsUploadDatabaseService.cs
@@ -2,11 +2,15 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Data.Common;
     using DataTransfer;
 
     public interface IStatsUploadDatabaseService
     {
-        void AddUsers(int downloadId, IEnumerable<UserData> usersData, IEnumerable<FailedUserData> failedUsers);
+        void AddUsers(DbTransaction transaction, int downloadId, IEnumerable<UserData> usersData,
+            IEnumerable<FailedUserData> failedUsers);
+
+        void Commit(DbTransaction transaction);
 
         IEnumerable<int> GetDownloadsReadyForUpload();
 
@@ -14,10 +18,12 @@
 
         bool IsAvailable();
 
-        void StartStatsUpload(int downloadId);
+        void Rollback(DbTransaction transaction);
+
+        DbTransaction StartStatsUpload(int downloadId);
 
         void StatsUploadError(StatsUploadResult statsUploadResult);
 
-        void StatsUploadFinished(int downloadId, DateTime downloadDateTime);
+        void StatsUploadFinished(DbTransaction transaction, int downloadId, DateTime downloadDateTime);
     }
 }

--- a/StatsDownload/StatsDownload.Core.Tests/TestErrorMessageProvider.cs
+++ b/StatsDownload/StatsDownload.Core.Tests/TestErrorMessageProvider.cs
@@ -137,7 +137,7 @@
         [Test]
         public void GetErrorMessage_WhenUnknownRejectionReason_ReturnsEmptyString()
         {
-            var actual = systemUnderTest.GetErrorMessage(new FailedUserData(0, string.Empty,
+            string actual = systemUnderTest.GetErrorMessage(new FailedUserData(0, string.Empty,
                 (RejectionReason) Enum.Parse(typeof (RejectionReason), "-1")));
 
             Assert.IsEmpty(actual);

--- a/StatsDownload/StatsDownload.Core.Tests/TestFileDownloadProvider.cs
+++ b/StatsDownload/StatsDownload.Core.Tests/TestFileDownloadProvider.cs
@@ -154,13 +154,13 @@
 
             InvokeDownloadFile();
 
-            Received.InOrder((() =>
+            Received.InOrder(() =>
             {
                 loggingServiceMock.LogVerbose("DownloadStatsFile Invoked");
                 fileDownloadDatabaseServiceMock.IsAvailable();
                 loggingServiceMock.LogResult(Arg.Any<FileDownloadResult>());
                 loggingServiceMock.LogException(expected);
-            }));
+            });
         }
 
         [Test]
@@ -219,11 +219,11 @@
 
             InvokeDownloadFile();
 
-            Received.InOrder((() =>
+            Received.InOrder(() =>
             {
                 loggingServiceMock.LogResult(Arg.Any<FileDownloadResult>());
                 loggingServiceMock.LogException(exception);
-            }));
+            });
         }
 
         [Test]
@@ -287,11 +287,11 @@
 
             InvokeDownloadFile();
 
-            Received.InOrder((() =>
+            Received.InOrder(() =>
             {
                 loggingServiceMock.LogResult(Arg.Any<FileDownloadResult>());
                 loggingServiceMock.LogException(exception);
-            }));
+            });
         }
 
         [Test]
@@ -340,7 +340,7 @@
         {
             InvokeDownloadFile();
 
-            Received.InOrder((() =>
+            Received.InOrder(() =>
             {
                 loggingServiceMock.LogVerbose("DownloadStatsFile Invoked");
                 fileDownloadDatabaseServiceMock.IsAvailable();
@@ -356,7 +356,7 @@
                 filePayloadUploadServiceMock.UploadFile(Arg.Any<FilePayload>());
                 resourceCleanupServiceMock.Cleanup(Arg.Any<FileDownloadResult>());
                 loggingServiceMock.LogResult(Arg.Any<FileDownloadResult>());
-            }));
+            });
         }
 
         [Test]

--- a/StatsDownload/StatsDownload.Core.Tests/TestGoogleUsersFilter.cs
+++ b/StatsDownload/StatsDownload.Core.Tests/TestGoogleUsersFilter.cs
@@ -39,7 +39,7 @@
             var expected = new ParseResults(downloadDateTime, null, null);
             innerServiceMock.Parse("fileData").Returns(expected);
 
-            var actual = systemUnderTest.Parse("fileData");
+            ParseResults actual = systemUnderTest.Parse("fileData");
 
             Assert.That(actual, Is.EqualTo(expected));
         }

--- a/StatsDownload/StatsDownload.Core.Tests/TestNoPaymentAddressUsersFilter.cs
+++ b/StatsDownload/StatsDownload.Core.Tests/TestNoPaymentAddressUsersFilter.cs
@@ -39,7 +39,7 @@
             var expected = new ParseResults(downloadDateTime, null, null);
             innerServiceMock.Parse("fileData").Returns(expected);
 
-            var actual = systemUnderTest.Parse("fileData");
+            ParseResults actual = systemUnderTest.Parse("fileData");
 
             Assert.That(actual, Is.EqualTo(expected));
         }

--- a/StatsDownload/StatsDownload.Core.Tests/TestSecureDownloadProvider.cs
+++ b/StatsDownload/StatsDownload.Core.Tests/TestSecureDownloadProvider.cs
@@ -98,11 +98,11 @@
 
             systemUnderTest.DownloadFile(filePayload);
 
-            Received.InOrder((() =>
+            Received.InOrder(() =>
             {
                 secureFilePayloadServiceMock.EnableSecureFilePayload(filePayload);
                 downloadServiceMock.DownloadFile(filePayload);
-            }));
+            });
         }
 
         [Test]
@@ -144,14 +144,14 @@
 
             systemUnderTest.DownloadFile(filePayload);
 
-            Received.InOrder((() =>
+            Received.InOrder(() =>
             {
                 secureFilePayloadServiceMock.EnableSecureFilePayload(filePayload);
                 downloadServiceMock.DownloadFile(filePayload);
                 loggingServiceMock.LogException(webException);
                 secureFilePayloadServiceMock.DisableSecureFilePayload(filePayload);
                 downloadServiceMock.DownloadFile(filePayload);
-            }));
+            });
         }
 
         private IDownloadService NewSecureDownloadProvider(IDownloadService downloadService,

--- a/StatsDownload/StatsDownload.Core.Tests/TestStatsDownloadDatabaseProvider.cs
+++ b/StatsDownload/StatsDownload.Core.Tests/TestStatsDownloadDatabaseProvider.cs
@@ -122,7 +122,7 @@
                 dbCommand => { throw new Exception(); }
             });
 
-            DbTransaction transactionMock = Substitute.For<DbTransaction>();
+            var transactionMock = Substitute.For<DbTransaction>();
             databaseConnectionServiceMock.CreateTransaction().Returns(transactionMock);
 
             Assert.Throws<Exception>(() =>
@@ -145,7 +145,7 @@
                 dbCommand => rebuildIndicesCommand = dbCommand
             });
 
-            DbTransaction transactionMock = Substitute.For<DbTransaction>();
+            var transactionMock = Substitute.For<DbTransaction>();
             databaseConnectionServiceMock.CreateTransaction().Returns(transactionMock);
 
             systemUnderTest.AddUsers(1, new List<UserData> { new UserData(), new UserData(), new UserData() },
@@ -315,7 +315,7 @@
                 dbCommand => command = dbCommand
             });
 
-            DbTransaction transactionMock = Substitute.For<DbTransaction>();
+            var transactionMock = Substitute.For<DbTransaction>();
             databaseConnectionServiceMock.CreateTransaction().Returns(transactionMock);
 
             systemUnderTest.AddUsers(1, null, null);
@@ -331,7 +331,7 @@
             DbCommand command = default(DbCommand);
             SetUpDatabaseConnectionCreateDbCommandMock(new Action<DbCommand>[] { dbCommand => command = dbCommand });
 
-            DbTransaction transactionMock = Substitute.For<DbTransaction>();
+            var transactionMock = Substitute.For<DbTransaction>();
             databaseConnectionServiceMock.CreateTransaction().Returns(transactionMock);
 
             systemUnderTest.AddUsers(1, null, null);
@@ -352,7 +352,7 @@
                 dbCommand => command = dbCommand
             });
 
-            DbTransaction transactionMock = Substitute.For<DbTransaction>();
+            var transactionMock = Substitute.For<DbTransaction>();
             databaseConnectionServiceMock.CreateTransaction().Returns(transactionMock);
 
             systemUnderTest.AddUsers(1, null, null);
@@ -446,13 +446,13 @@
         {
             InvokeFileDownloadError();
 
-            Received.InOrder((() =>
+            Received.InOrder(() =>
             {
                 loggingServiceMock.LogVerbose("FileDownloadError Invoked");
                 loggingServiceMock.LogVerbose("Database connection was successful");
                 databaseConnectionServiceMock.ExecuteStoredProcedure("[FoldingCoin].[FileDownloadError]",
                     Arg.Any<List<DbParameter>>());
-            }));
+            });
         }
 
         [Test]
@@ -641,12 +641,12 @@
 
             InvokeIsAvailable();
 
-            Received.InOrder((() =>
+            Received.InOrder(() =>
             {
                 loggingServiceMock.LogVerbose("IsAvailable Invoked");
                 databaseConnectionServiceMock.Open();
                 loggingServiceMock.LogVerbose("Database connection was successful");
-            }));
+            });
         }
 
         [Test]
@@ -668,12 +668,12 @@
 
             InvokeIsAvailable();
 
-            Received.InOrder((() =>
+            Received.InOrder(() =>
             {
                 loggingServiceMock.LogVerbose("IsAvailable Invoked");
                 databaseConnectionServiceMock.Open();
                 loggingServiceMock.LogException(expected);
-            }));
+            });
         }
 
         [Test]
@@ -718,13 +718,13 @@
         {
             InvokeNewFileDownloadStarted();
 
-            Received.InOrder((() =>
+            Received.InOrder(() =>
             {
                 loggingServiceMock.LogVerbose("NewFileDownloadStarted Invoked");
                 loggingServiceMock.LogVerbose("Database connection was successful");
                 databaseConnectionServiceMock.ExecuteStoredProcedure("[FoldingCoin].[NewFileDownloadStarted]",
                     Arg.Any<List<DbParameter>>());
-            }));
+            });
         }
 
         [Test]
@@ -854,7 +854,7 @@
                                                      Arg.Any<List<DbParameter>>()))
                                          .Do(callback => { actualParameters = callback.Arg<List<DbParameter>>(); });
 
-            var dateTime = DateTime.UtcNow;
+            DateTime dateTime = DateTime.UtcNow;
 
             systemUnderTest.StatsUploadFinished(100, dateTime);
 
@@ -874,13 +874,13 @@
         {
             systemUnderTest.StatsUploadFinished(100, DateTime.Now);
 
-            Received.InOrder((() =>
+            Received.InOrder(() =>
             {
                 loggingServiceMock.LogVerbose("StatsUploadFinished Invoked");
                 loggingServiceMock.LogVerbose("Database connection was successful");
                 databaseConnectionServiceMock.ExecuteStoredProcedure("[FoldingCoin].[StatsUploadFinished]",
                     Arg.Any<List<DbParameter>>());
-            }));
+            });
         }
 
         [Test]
@@ -891,13 +891,13 @@
 
             InvokeUpdateToLatest();
 
-            Received.InOrder((() =>
+            Received.InOrder(() =>
             {
                 loggingServiceMock.LogVerbose("UpdateToLatest Invoked");
                 loggingServiceMock.LogVerbose("Database connection was successful");
                 databaseConnectionServiceMock.ExecuteStoredProcedure("[FoldingCoin].[UpdateToLatest]");
                 loggingServiceMock.LogVerbose($"'{NumberOfRowsEffectedExpected}' rows were effected");
-            }));
+            });
         }
 
         private const int NumberOfRowsEffectedExpected = 5;

--- a/StatsDownload/StatsDownload.Core.Tests/TestStatsFileParserProvider.cs
+++ b/StatsDownload/StatsDownload.Core.Tests/TestStatsFileParserProvider.cs
@@ -50,7 +50,7 @@
         public void Parse_WhenInvoked_ReturnsDownloadDateTimeInUTC(string fileData, int year, int month, int day,
             int hour, int minute, int second)
         {
-            var actual = InvokeParse(fileData).DownloadDateTime;
+            DateTime actual = InvokeParse(fileData).DownloadDateTime;
 
             Assert.That(actual, Is.EqualTo(new DateTime(year, month, day, hour, minute, second)));
         }

--- a/StatsDownload/StatsDownload.Core.Tests/TestStatsUploadProvider.cs
+++ b/StatsDownload/StatsDownload.Core.Tests/TestStatsUploadProvider.cs
@@ -292,12 +292,12 @@
 
             Received.InOrder(() =>
             {
-                statsUploadDatabaseServiceMock.StartStatsUpload(1);
                 statsUploadDatabaseServiceMock.GetFileData(1);
+                statsUploadDatabaseServiceMock.StartStatsUpload(1);
                 statsUploadDatabaseServiceMock.StatsUploadFinished(tranaction1, 1, downloadDateTime);
                 statsUploadDatabaseServiceMock.Commit(tranaction1);
-                statsUploadDatabaseServiceMock.StartStatsUpload(2);
                 statsUploadDatabaseServiceMock.GetFileData(2);
+                statsUploadDatabaseServiceMock.StartStatsUpload(2);
                 statsUploadDatabaseServiceMock.StatsUploadFinished(tranaction2, 2, downloadDateTime);
                 statsUploadDatabaseServiceMock.Commit(tranaction2);
             });

--- a/StatsDownload/StatsDownload.Core.Tests/TestStatsUploadProvider.cs
+++ b/StatsDownload/StatsDownload.Core.Tests/TestStatsUploadProvider.cs
@@ -219,13 +219,13 @@
             Received.InOrder(() =>
             {
                 statsUploadDatabaseServiceMock.AddUsers(1,
-                    Arg.Is<IEnumerable<UserData>>((datas => datas.Contains(user1) && datas.Contains(user2))),
+                    Arg.Is<IEnumerable<UserData>>(datas => datas.Contains(user1) && datas.Contains(user2)),
                     Arg.Is<IEnumerable<FailedUserData>>(
-                        (data => data.Contains(failedUser1) && data.Contains(failedUser2))));
+                        data => data.Contains(failedUser1) && data.Contains(failedUser2)));
                 statsUploadDatabaseServiceMock.AddUsers(2,
-                    Arg.Is<IEnumerable<UserData>>((datas => datas.Contains(user3) && datas.Contains(user4))),
+                    Arg.Is<IEnumerable<UserData>>(datas => datas.Contains(user3) && datas.Contains(user4)),
                     Arg.Is<IEnumerable<FailedUserData>>(
-                        (data => data.Contains(failedUser3) && data.Contains(failedUser4))));
+                        data => data.Contains(failedUser3) && data.Contains(failedUser4)));
             });
         }
 

--- a/StatsDownload/StatsDownload.Core.Tests/TestWhitespaceNameUsersFilter.cs
+++ b/StatsDownload/StatsDownload.Core.Tests/TestWhitespaceNameUsersFilter.cs
@@ -39,7 +39,7 @@
             var expected = new ParseResults(downloadDateTime, null, null);
             innerServiceMock.Parse("fileData").Returns(expected);
 
-            var actual = systemUnderTest.Parse("fileData");
+            ParseResults actual = systemUnderTest.Parse("fileData");
 
             Assert.That(actual, Is.EqualTo(expected));
         }

--- a/StatsDownload/StatsDownload.Core.Tests/TestZeroPointUsersFilter.cs
+++ b/StatsDownload/StatsDownload.Core.Tests/TestZeroPointUsersFilter.cs
@@ -39,7 +39,7 @@
             var expected = new ParseResults(downloadDateTime, null, null);
             innerServiceMock.Parse("fileData").Returns(expected);
 
-            var actual = systemUnderTest.Parse("fileData");
+            ParseResults actual = systemUnderTest.Parse("fileData");
 
             Assert.That(actual, Is.EqualTo(expected));
         }

--- a/StatsDownload/StatsDownload.Core/Constants.cs
+++ b/StatsDownload/StatsDownload.Core/Constants.cs
@@ -78,16 +78,16 @@
         {
             public const string ExpectedHeader = @"name	newcredit	sum(total)	team";
 
-            public static string[] StandardDateTimeFormats =
-            {
-                "ddd MMM  d HH:mm:ss PST yyyy",
-                "ddd MMM dd HH:mm:ss PST yyyy"
-            };
-
             public static string[] DaylightSavingsDateTimeFormats =
             {
                 "ddd MMM  d HH:mm:ss PDT yyyy",
                 "ddd MMM dd HH:mm:ss PDT yyyy"
+            };
+
+            public static string[] StandardDateTimeFormats =
+            {
+                "ddd MMM  d HH:mm:ss PST yyyy",
+                "ddd MMM dd HH:mm:ss PST yyyy"
             };
         }
     }

--- a/StatsDownload/StatsDownload.Core/Implementations/StatsDownloadDatabaseProvider.cs
+++ b/StatsDownload/StatsDownload.Core/Implementations/StatsDownloadDatabaseProvider.cs
@@ -166,6 +166,24 @@
             }
         }
 
+        private void AddUsers(IDatabaseConnectionService databaseConnection, int downloadId,
+            IEnumerable<UserData> users, IEnumerable<FailedUserData> failedUsers)
+        {
+            DbTransaction transaction = databaseConnection.CreateTransaction();
+
+            try
+            {
+                AddUserRejections(databaseConnection, transaction, downloadId, failedUsers);
+                AddUsersData(databaseConnection, transaction, downloadId, users);
+                transaction?.Commit();
+            }
+            catch (Exception)
+            {
+                transaction?.Rollback();
+                throw;
+            }
+        }
+
         private void AddUsersData(IDatabaseConnectionService databaseConnection, DbTransaction transaction,
             int downloadId,
             IEnumerable<UserData> usersData)
@@ -197,24 +215,6 @@
                         }
                     }
                 }
-            }
-        }
-
-        private void AddUsers(IDatabaseConnectionService databaseConnection, int downloadId,
-            IEnumerable<UserData> users, IEnumerable<FailedUserData> failedUsers)
-        {
-            var transaction = databaseConnection.CreateTransaction();
-
-            try
-            {
-                AddUserRejections(databaseConnection, transaction, downloadId, failedUsers);
-                AddUsersData(databaseConnection, transaction, downloadId, users);
-                transaction?.Commit();
-            }
-            catch (Exception)
-            {
-                transaction?.Rollback();
-                throw;
             }
         }
 
@@ -493,7 +493,7 @@
         {
             DbParameter download = CreateDownloadIdParameter(databaseConnection, downloadId);
 
-            var downloadDateTimeParameter =
+            DbParameter downloadDateTimeParameter =
                 databaseConnection.CreateParameter("@DownloadDateTime", DbType.DateTime, ParameterDirection.Input);
             downloadDateTimeParameter.Value = downloadDateTime;
 

--- a/StatsDownload/StatsDownload.Core/Implementations/StatsDownloadDatabaseProvider.cs
+++ b/StatsDownload/StatsDownload.Core/Implementations/StatsDownloadDatabaseProvider.cs
@@ -52,10 +52,19 @@
             this.errorMessageService = errorMessageService;
         }
 
-        public void AddUsers(int downloadId, IEnumerable<UserData> users, IEnumerable<FailedUserData> failedUsers)
+        public void Rollback(DbTransaction transaction)
+        {
+            transaction?.Rollback();
+        }
+
+        public void AddUsers(DbTransaction transaction, int downloadId, IEnumerable<UserData> users,
+            IEnumerable<FailedUserData> failedUsers)
         {
             LogMethodInvoked();
-            CreateDatabaseConnectionAndExecuteAction(service => { AddUsers(service, downloadId, users, failedUsers); });
+            CreateDatabaseConnectionAndExecuteAction(service =>
+            {
+                AddUsers(transaction, service, downloadId, users, failedUsers);
+            });
         }
 
         public void FileDownloadError(FileDownloadResult fileDownloadResult)
@@ -68,6 +77,11 @@
         {
             LogMethodInvoked();
             CreateDatabaseConnectionAndExecuteAction(service => { FileDownloadFinished(service, filePayload); });
+        }
+
+        public void Commit(DbTransaction transaction)
+        {
+            transaction?.Commit();
         }
 
         public IEnumerable<int> GetDownloadsReadyForUpload()
@@ -120,10 +134,12 @@
             filePayload.DownloadId = downloadId;
         }
 
-        public void StartStatsUpload(int downloadId)
+        public DbTransaction StartStatsUpload(int downloadId)
         {
             LogMethodInvoked();
-            CreateDatabaseConnectionAndExecuteAction(service => StartStatsUpload(service, downloadId));
+            DbTransaction transaction = null;
+            CreateDatabaseConnectionAndExecuteAction(service => transaction = StartStatsUpload(service, downloadId));
+            return transaction;
         }
 
         public void StatsUploadError(StatsUploadResult statsUploadResult)
@@ -132,11 +148,11 @@
             CreateDatabaseConnectionAndExecuteAction(service => StatsUploadError(service, statsUploadResult));
         }
 
-        public void StatsUploadFinished(int downloadId, DateTime downloadDateTime)
+        public void StatsUploadFinished(DbTransaction transaction, int downloadId, DateTime downloadDateTime)
         {
             LogMethodInvoked();
             CreateDatabaseConnectionAndExecuteAction(service =>
-                StatsUploadFinished(service, downloadId, downloadDateTime));
+                StatsUploadFinished(transaction, service, downloadId, downloadDateTime));
         }
 
         public void UpdateToLatest()
@@ -166,22 +182,11 @@
             }
         }
 
-        private void AddUsers(IDatabaseConnectionService databaseConnection, int downloadId,
+        private void AddUsers(DbTransaction transaction, IDatabaseConnectionService databaseConnection, int downloadId,
             IEnumerable<UserData> users, IEnumerable<FailedUserData> failedUsers)
         {
-            DbTransaction transaction = databaseConnection.CreateTransaction();
-
-            try
-            {
-                AddUserRejections(databaseConnection, transaction, downloadId, failedUsers);
-                AddUsersData(databaseConnection, transaction, downloadId, users);
-                transaction?.Commit();
-            }
-            catch (Exception)
-            {
-                transaction?.Rollback();
-                throw;
-            }
+            AddUserRejections(databaseConnection, transaction, downloadId, failedUsers);
+            AddUsersData(databaseConnection, transaction, downloadId, users);
         }
 
         private void AddUsersData(IDatabaseConnectionService databaseConnection, DbTransaction transaction,
@@ -470,12 +475,17 @@
             parameters.RejectionReason.Value = errorMessageService.GetErrorMessage(failedUserData);
         }
 
-        private void StartStatsUpload(IDatabaseConnectionService databaseConnection, int downloadId)
+        private DbTransaction StartStatsUpload(IDatabaseConnectionService databaseConnection, int downloadId)
         {
+            DbTransaction transaction = databaseConnection.CreateTransaction();
+
             DbParameter download = CreateDownloadIdParameter(databaseConnection, downloadId);
 
-            databaseConnection.ExecuteStoredProcedure(Constants.StatsDownloadDatabase.StartStatsUploadProcedureName,
+            databaseConnection.ExecuteStoredProcedure(transaction,
+                Constants.StatsDownloadDatabase.StartStatsUploadProcedureName,
                 new List<DbParameter> { download });
+
+            return transaction;
         }
 
         private void StatsUploadError(IDatabaseConnectionService databaseConnection,
@@ -488,7 +498,8 @@
                 new List<DbParameter> { downloadId, errorMessage });
         }
 
-        private void StatsUploadFinished(IDatabaseConnectionService databaseConnection, int downloadId,
+        private void StatsUploadFinished(DbTransaction transaction, IDatabaseConnectionService databaseConnection,
+            int downloadId,
             DateTime downloadDateTime)
         {
             DbParameter download = CreateDownloadIdParameter(databaseConnection, downloadId);
@@ -497,7 +508,8 @@
                 databaseConnection.CreateParameter("@DownloadDateTime", DbType.DateTime, ParameterDirection.Input);
             downloadDateTimeParameter.Value = downloadDateTime;
 
-            databaseConnection.ExecuteStoredProcedure(Constants.StatsDownloadDatabase.StatsUploadFinishedProcedureName,
+            databaseConnection.ExecuteStoredProcedure(transaction,
+                Constants.StatsDownloadDatabase.StatsUploadFinishedProcedureName,
                 new List<DbParameter> { download, downloadDateTimeParameter });
         }
 

--- a/StatsDownload/StatsDownload.Core/Implementations/StatsUploadProvider.cs
+++ b/StatsDownload/StatsDownload.Core/Implementations/StatsUploadProvider.cs
@@ -120,8 +120,8 @@
             try
             {
                 LogVerbose($"Starting stats file upload. DownloadId: {downloadId}");
-                transaction = statsUploadDatabaseService.StartStatsUpload(downloadId);
                 string fileData = statsUploadDatabaseService.GetFileData(downloadId);
+                transaction = statsUploadDatabaseService.StartStatsUpload(downloadId);
                 ParseResults results = statsFileParserService.Parse(fileData);
                 IEnumerable<UserData> usersData = results.UsersData;
                 IEnumerable<FailedUserData> failedUsersData = results.FailedUsersData;

--- a/StatsDownload/StatsDownload.Core/Implementations/StatsUploadProvider.cs
+++ b/StatsDownload/StatsDownload.Core/Implementations/StatsUploadProvider.cs
@@ -86,6 +86,22 @@
             return !statsUploadDatabaseService.IsAvailable();
         }
 
+        private void HandleUsers(int downloadId, IEnumerable<UserData> usersData,
+            IEnumerable<FailedUserData> failedUsersData)
+        {
+            statsUploadDatabaseService.AddUsers(downloadId, usersData, failedUsersData);
+
+            if (failedUsersData.Any())
+            {
+                statsUploadEmailService.SendEmail(failedUsersData);
+            }
+
+            foreach (FailedUserData failedUserData in failedUsersData)
+            {
+                loggingService.LogFailedUserData(downloadId, failedUserData);
+            }
+        }
+
         private void LogVerbose(string message)
         {
             loggingService.LogVerbose(message);
@@ -117,22 +133,6 @@
                 statsUploadEmailService.SendEmail(failedStatsUploadResult);
                 statsUploadDatabaseService.StatsUploadError(failedStatsUploadResult);
                 statsUploadResults.Add(failedStatsUploadResult);
-            }
-        }
-
-        private void HandleUsers(int downloadId, IEnumerable<UserData> usersData,
-            IEnumerable<FailedUserData> failedUsersData)
-        {
-            statsUploadDatabaseService.AddUsers(downloadId, usersData, failedUsersData);
-
-            if (failedUsersData.Any())
-            {
-                statsUploadEmailService.SendEmail(failedUsersData);
-            }
-
-            foreach (FailedUserData failedUserData in failedUsersData)
-            {
-                loggingService.LogFailedUserData(downloadId, failedUserData);
             }
         }
     }

--- a/StatsDownload/StatsDownload.Core/Wrappers/MicrosoftSqlDatabaseConnectionProvider.cs
+++ b/StatsDownload/StatsDownload.Core/Wrappers/MicrosoftSqlDatabaseConnectionProvider.cs
@@ -108,6 +108,19 @@
             }
         }
 
+        public int ExecuteStoredProcedure(DbTransaction transaction, string storedProcedure,
+            IEnumerable<DbParameter> parameters)
+        {
+            using (DbCommand command = CreateDbCommand())
+            {
+                command.CommandText = storedProcedure;
+                command.CommandType = CommandType.StoredProcedure;
+                command.Transaction = transaction;
+                command.Parameters.AddRange(parameters?.ToArray() ?? new DbParameter[0]);
+                return command.ExecuteNonQuery();
+            }
+        }
+
         public int ExecuteStoredProcedure(string storedProcedure)
         {
             return ExecuteStoredProcedure(storedProcedure, null);

--- a/StatsDownload/StatsDownload.Core/Wrappers/MicrosoftSqlDatabaseConnectionProvider.cs
+++ b/StatsDownload/StatsDownload.Core/Wrappers/MicrosoftSqlDatabaseConnectionProvider.cs
@@ -27,6 +27,11 @@
 
         public ConnectionState ConnectionState => sqlConnection.State;
 
+        public void Close()
+        {
+            sqlConnection.Close();
+        }
+
         public DbCommand CreateDbCommand()
         {
             DbCommand dbCommand = sqlConnection.CreateCommand();

--- a/StatsDownload/StatsDownload.Core/Wrappers/MySqlDatabaseConnectionProvider.cs
+++ b/StatsDownload/StatsDownload.Core/Wrappers/MySqlDatabaseConnectionProvider.cs
@@ -114,6 +114,11 @@
             sqlConnection.Open();
         }
 
+        public void Close()
+        {
+            sqlConnection.Close();
+        }
+
         private void SetCommandTimeout(DbCommand dbCommand)
         {
             if (commandTimeout.HasValue)

--- a/StatsDownload/StatsDownload.Core/Wrappers/MySqlDatabaseConnectionProvider.cs
+++ b/StatsDownload/StatsDownload.Core/Wrappers/MySqlDatabaseConnectionProvider.cs
@@ -35,6 +35,19 @@
             return dbCommand;
         }
 
+        public int ExecuteStoredProcedure(DbTransaction transaction, string storedProcedure,
+            IEnumerable<DbParameter> parameters)
+        {
+            using (DbCommand command = CreateDbCommand())
+            {
+                command.CommandText = storedProcedure;
+                command.CommandType = CommandType.StoredProcedure;
+                command.Transaction = transaction;
+                command.Parameters.AddRange(parameters?.ToArray() ?? new DbParameter[0]);
+                return command.ExecuteNonQuery();
+            }
+        }
+
         public DbTransaction CreateTransaction()
         {
             return sqlConnection.BeginTransaction();

--- a/StatsDownload/StatsDownload.Core/Wrappers/Networking/WebClientWrapper.cs
+++ b/StatsDownload/StatsDownload.Core/Wrappers/Networking/WebClientWrapper.cs
@@ -18,14 +18,14 @@
 
         public Func<X509Certificate, X509Chain, SslPolicyErrors, bool> SslPolicyOverride
         {
-            get { return innerWebClient.SslPolicyOverride; }
-            set { innerWebClient.SslPolicyOverride = value; }
+            get => innerWebClient.SslPolicyOverride;
+            set => innerWebClient.SslPolicyOverride = value;
         }
 
         public TimeSpan Timeout
         {
-            get { return innerWebClient.Timeout; }
-            set { innerWebClient.Timeout = value; }
+            get => innerWebClient.Timeout;
+            set => innerWebClient.Timeout = value;
         }
 
         public void Dispose()

--- a/StatsDownload/StatsDownload.Email.Tests/TestEmailSettingsValidatorProvider.cs
+++ b/StatsDownload/StatsDownload.Email.Tests/TestEmailSettingsValidatorProvider.cs
@@ -19,7 +19,7 @@
         [TestCase(null)]
         public void ParseFromAddress_WhenInvalidFromAddress_ThrowsEmailArgumentException(string unsafeFromAddress)
         {
-            Assert.Throws<EmailArgumentException>((() => systemUnderTest.ParseFromAddress(unsafeFromAddress)));
+            Assert.Throws<EmailArgumentException>(() => systemUnderTest.ParseFromAddress(unsafeFromAddress));
         }
 
         [TestCase("user@domain.com")]
@@ -35,7 +35,7 @@
         public void ParseFromDisplayName_WhenInvalidFromDisplayName_ThrowsEmailArgumentException(
             string unsafeFromDisplayName)
         {
-            Assert.Throws<EmailArgumentException>((() => systemUnderTest.ParseFromDisplayName(unsafeFromDisplayName)));
+            Assert.Throws<EmailArgumentException>(() => systemUnderTest.ParseFromDisplayName(unsafeFromDisplayName));
         }
 
         [TestCase("Display Name")]
@@ -50,7 +50,7 @@
         [TestCase(null)]
         public void ParsePassword_WhenInvalidPassword_ThrowsEmailArgumentException(string unsafePassword)
         {
-            Assert.Throws<EmailArgumentException>((() => systemUnderTest.ParsePassword(unsafePassword)));
+            Assert.Throws<EmailArgumentException>(() => systemUnderTest.ParsePassword(unsafePassword));
         }
 
         [TestCase("password")]
@@ -90,7 +90,7 @@
         [TestCase("")]
         public void ParseReceivers_WhenInvokedWithInvalidReceiver_ThrowsEmailArgumentException(string unsafeReceivers)
         {
-            Assert.Throws<EmailArgumentException>((() => systemUnderTest.ParseReceivers(unsafeReceivers)));
+            Assert.Throws<EmailArgumentException>(() => systemUnderTest.ParseReceivers(unsafeReceivers));
         }
 
         [TestCase("user@domain.tld")]
@@ -118,7 +118,7 @@
         [TestCase(null)]
         public void ParseSmtpHost_WhenInvalidSmtpHost_ThrowsEmailArgumentException(string unsafeSmtpHost)
         {
-            Assert.Throws<EmailArgumentException>((() => systemUnderTest.ParseSmtpHost(unsafeSmtpHost)));
+            Assert.Throws<EmailArgumentException>(() => systemUnderTest.ParseSmtpHost(unsafeSmtpHost));
         }
 
         [TestCase("google.com")]

--- a/StatsDownload/StatsDownload.FileDownload.Console/App.config
+++ b/StatsDownload/StatsDownload.FileDownload.Console/App.config
@@ -6,7 +6,7 @@
   </startup>
   <connectionStrings>
     <add name="FoldingCoin"
-         connectionString="Server=(localdb)\MSSQLLocalDB;Database=FoldingCoin;Integrated Security=true;" />
+         connectionString="Server=(localdb)\MSSQLLocalDB;Database=FoldingCoin;Integrated Security=true;ConnectRetryCount=1;" />
   </connectionStrings>
   <appSettings>
     <!--Identify the database type 'MicrosoftSql' or 'MySql'; default is MicrosoftSql-->

--- a/StatsDownload/StatsDownload.FileDownload.Console/CastleWindsor/DatabaseFactoryComponentSelector.cs
+++ b/StatsDownload/StatsDownload.FileDownload.Console/CastleWindsor/DatabaseFactoryComponentSelector.cs
@@ -17,7 +17,7 @@
 
         protected override string GetComponentName(MethodInfo method, object[] arguments)
         {
-            var databaseType = settings.GetDatabaseType();
+            string databaseType = settings.GetDatabaseType();
             if (string.Equals(databaseType, "MySql", StringComparison.OrdinalIgnoreCase))
             {
                 return typeof (MySqlDatabaseConnectionProvider).FullName;

--- a/StatsDownload/StatsDownload.FileDownload.Console/CastleWindsor/WindsorContainer.cs
+++ b/StatsDownload/StatsDownload.FileDownload.Console/CastleWindsor/WindsorContainer.cs
@@ -6,9 +6,9 @@
 
     internal static class WindsorContainer
     {
-        private static readonly object sync = new object();
-
         private static IWindsorContainer innerContainer;
+
+        private static readonly object sync = new object();
 
         internal static IWindsorContainer Instance
         {
@@ -21,6 +21,13 @@
             }
         }
 
+        private static IWindsorContainer CreateWindsorContainer()
+        {
+            var container = new CastleWindsorContainer();
+            container.AddFacility<TypedFactoryFacility>();
+            return container;
+        }
+
         public static void Dispose()
         {
             lock (sync)
@@ -28,13 +35,6 @@
                 innerContainer?.Dispose();
                 innerContainer = null;
             }
-        }
-
-        private static IWindsorContainer CreateWindsorContainer()
-        {
-            var container = new CastleWindsorContainer();
-            container.AddFacility<TypedFactoryFacility>();
-            return container;
         }
     }
 }

--- a/StatsDownload/StatsDownload.FileServer.TestHarness/CastleWindsor/WindsorContainer.cs
+++ b/StatsDownload/StatsDownload.FileServer.TestHarness/CastleWindsor/WindsorContainer.cs
@@ -6,9 +6,9 @@
 
     internal static class WindsorContainer
     {
-        private static readonly object sync = new object();
-
         private static IWindsorContainer innerContainer;
+
+        private static readonly object sync = new object();
 
         internal static IWindsorContainer Instance
         {
@@ -21,6 +21,13 @@
             }
         }
 
+        private static IWindsorContainer CreateWindsorContainer()
+        {
+            var container = new CastleWindsorContainer();
+            container.AddFacility<WcfFacility>();
+            return container;
+        }
+
         public static void Dispose()
         {
             lock (sync)
@@ -28,13 +35,6 @@
                 innerContainer?.Dispose();
                 innerContainer = null;
             }
-        }
-
-        private static IWindsorContainer CreateWindsorContainer()
-        {
-            var container = new CastleWindsorContainer();
-            container.AddFacility<WcfFacility>();
-            return container;
         }
     }
 }

--- a/StatsDownload/StatsDownload.StatsUpload.Console/App.config
+++ b/StatsDownload/StatsDownload.StatsUpload.Console/App.config
@@ -6,7 +6,7 @@
   </startup>
   <connectionStrings>
     <add name="FoldingCoin"
-         connectionString="Server=(localdb)\MSSQLLocalDB;Database=FoldingCoin;Integrated Security=true;" />
+         connectionString="Server=(localdb)\MSSQLLocalDB;Database=FoldingCoin;Integrated Security=true;ConnectRetryCount=1;" />
   </connectionStrings>
   <appSettings>
     <!--Identify the database type 'MicrosoftSql' or 'MySql'; default is MicrosoftSql-->

--- a/StatsDownload/StatsDownload.StatsUpload.Console/CastleWindsor/DatabaseFactoryComponentSelector.cs
+++ b/StatsDownload/StatsDownload.StatsUpload.Console/CastleWindsor/DatabaseFactoryComponentSelector.cs
@@ -17,7 +17,7 @@
 
         protected override string GetComponentName(MethodInfo method, object[] arguments)
         {
-            var databaseType = settings.GetDatabaseType();
+            string databaseType = settings.GetDatabaseType();
             if (string.Equals(databaseType, "MySql", StringComparison.OrdinalIgnoreCase))
             {
                 return typeof (MySqlDatabaseConnectionProvider).FullName;

--- a/StatsDownload/StatsDownload.StatsUpload.Console/CastleWindsor/WindsorContainer.cs
+++ b/StatsDownload/StatsDownload.StatsUpload.Console/CastleWindsor/WindsorContainer.cs
@@ -6,9 +6,9 @@
 
     internal static class WindsorContainer
     {
-        private static readonly object sync = new object();
-
         private static IWindsorContainer innerContainer;
+
+        private static readonly object sync = new object();
 
         internal static IWindsorContainer Instance
         {
@@ -21,6 +21,13 @@
             }
         }
 
+        private static IWindsorContainer CreateWindsorContainer()
+        {
+            var container = new CastleWindsorContainer();
+            container.AddFacility<TypedFactoryFacility>();
+            return container;
+        }
+
         public static void Dispose()
         {
             lock (sync)
@@ -28,13 +35,6 @@
                 innerContainer?.Dispose();
                 innerContainer = null;
             }
-        }
-
-        private static IWindsorContainer CreateWindsorContainer()
-        {
-            var container = new CastleWindsorContainer();
-            container.AddFacility<TypedFactoryFacility>();
-            return container;
         }
     }
 }

--- a/StatsDownload/StatsDownload.TestHarness/App.config
+++ b/StatsDownload/StatsDownload.TestHarness/App.config
@@ -86,7 +86,7 @@
     <!--Test Harness Only Configuration-->
     <!--Enabling the one hundred users filter will filter out users after on hundred users-->
     <!--<add key="EnableOneHundredUsersFilter" value="true"/>-->
-    
+
     <!--Test Harness Only Configuration-->
     <!--Enabling the sql exception during AddUsers test will throw a SQL exception after adding two users-->
     <!--<add key="EnableSqlExceptionDuringAddUsersTest" value="true"/>-->

--- a/StatsDownload/StatsDownload.TestHarness/App.config
+++ b/StatsDownload/StatsDownload.TestHarness/App.config
@@ -86,5 +86,9 @@
     <!--Test Harness Only Configuration-->
     <!--Enabling the one hundred users filter will filter out users after on hundred users-->
     <!--<add key="EnableOneHundredUsersFilter" value="true"/>-->
+    
+    <!--Test Harness Only Configuration-->
+    <!--Enabling the sql exception during AddUsers test will throw a SQL exception after adding two users-->
+    <!--<add key="EnableSqlExceptionDuringAddUsersTest" value="true"/>-->
   </appSettings>
 </configuration>

--- a/StatsDownload/StatsDownload.TestHarness/App.config
+++ b/StatsDownload/StatsDownload.TestHarness/App.config
@@ -6,7 +6,7 @@
   </startup>
   <connectionStrings>
     <add name="FoldingCoin"
-         connectionString="Server=(localdb)\MSSQLLocalDB;Database=FoldingCoin;Integrated Security=true;" />
+         connectionString="Server=(localdb)\MSSQLLocalDB;Database=FoldingCoin;Integrated Security=true;ConnectRetryCount=1;" />
   </connectionStrings>
   <appSettings>
     <!--Identify the database type 'MicrosoftSql' or 'MySql'; default is MicrosoftSql-->

--- a/StatsDownload/StatsDownload.TestHarness/CastleWindsor/DatabaseFactoryComponentSelector.cs
+++ b/StatsDownload/StatsDownload.TestHarness/CastleWindsor/DatabaseFactoryComponentSelector.cs
@@ -17,7 +17,7 @@
 
         protected override string GetComponentName(MethodInfo method, object[] arguments)
         {
-            var databaseType = settings.GetDatabaseType();
+            string databaseType = settings.GetDatabaseType();
             if (string.Equals(databaseType, "MySql", StringComparison.OrdinalIgnoreCase))
             {
                 return typeof (MySqlDatabaseConnectionProvider).FullName;

--- a/StatsDownload/StatsDownload.TestHarness/CastleWindsor/DependencyInstaller.cs
+++ b/StatsDownload/StatsDownload.TestHarness/CastleWindsor/DependencyInstaller.cs
@@ -27,7 +27,9 @@
                 Component.For<IFileDownloadMinimumWaitTimeService>()
                          .ImplementedBy<TestHarnessMinimumWaitTimeProvider>(),
                 Component.For<ISecureFilePayloadService>().ImplementedBy<TestHarnessSecureHttpFilePayloadProvider>(),
-                Component.For<IStatsFileParserService>().ImplementedBy<TestHarnessOneHundredUsersFilter>());
+                Component.For<IStatsFileParserService>().ImplementedBy<TestHarnessOneHundredUsersFilter>(),
+                Component.For<IFileDownloadDatabaseService, IStatsUploadDatabaseService>()
+                         .ImplementedBy<TestHarnessStatsDownloadDatabaseProvider>());
 
             container.Register(Component.For<IDateTimeService>().ImplementedBy<DateTimeProvider>(),
                 Component.For<IFileService>().ImplementedBy<FileProvider>(),
@@ -45,8 +47,9 @@
                 Component.For<ITypedFactoryComponentSelector>().ImplementedBy<DatabaseFactoryComponentSelector>(),
                 Component.For<IDatabaseConnectionServiceFactory>().AsFactory(selector =>
                     selector.SelectedWith<DatabaseFactoryComponentSelector>()),
-                Component.For<IFileDownloadDatabaseService, IStatsUploadDatabaseService>()
-                         .ImplementedBy<StatsDownloadDatabaseProvider>(),
+                Component
+                    .For<IFileDownloadDatabaseService, IStatsUploadDatabaseService, IStatsDownloadDatabaseService>()
+                    .ImplementedBy<StatsDownloadDatabaseProvider>(),
                 Component.For<ISecureFilePayloadService>().ImplementedBy<SecureFilePayloadProvider>(),
                 Component.For<IDownloadService>().ImplementedBy<SecureDownloadProvider>(),
                 Component.For<IDownloadService>().ImplementedBy<DownloadProvider>(),

--- a/StatsDownload/StatsDownload.TestHarness/CastleWindsor/DependencyInstaller.cs
+++ b/StatsDownload/StatsDownload.TestHarness/CastleWindsor/DependencyInstaller.cs
@@ -21,7 +21,8 @@
             container.Register(Component.For<IApplicationLoggingService>().ImplementedBy<TestHarnessLoggingProvider>(),
                 Component
                     .For<IDatabaseConnectionSettingsService, IDownloadSettingsService, ITestHarnessSettingsService,
-                        IEmailSettingsService>().ImplementedBy<TestHarnessSettingsProvider>()
+                        IEmailSettingsService, ITestHarnessStatsDownloadSettings>()
+                    .ImplementedBy<TestHarnessSettingsProvider>()
                     .Forward<IZeroPointUsersFilterSettings, IGoogleUsersFilterSettings,
                         IWhitespaceNameUsersFilterSettings, INoPaymentAddressUsersFilterSettings>(),
                 Component.For<IFileDownloadMinimumWaitTimeService>()

--- a/StatsDownload/StatsDownload.TestHarness/CastleWindsor/WindsorContainer.cs
+++ b/StatsDownload/StatsDownload.TestHarness/CastleWindsor/WindsorContainer.cs
@@ -6,9 +6,9 @@
 
     internal static class WindsorContainer
     {
-        private static readonly object sync = new object();
-
         private static IWindsorContainer innerContainer;
+
+        private static readonly object sync = new object();
 
         internal static IWindsorContainer Instance
         {
@@ -21,6 +21,13 @@
             }
         }
 
+        private static IWindsorContainer CreateWindsorContainer()
+        {
+            var container = new CastleWindsorContainer();
+            container.AddFacility<TypedFactoryFacility>();
+            return container;
+        }
+
         public static void Dispose()
         {
             lock (sync)
@@ -28,13 +35,6 @@
                 innerContainer?.Dispose();
                 innerContainer = null;
             }
-        }
-
-        private static IWindsorContainer CreateWindsorContainer()
-        {
-            var container = new CastleWindsorContainer();
-            container.AddFacility<TypedFactoryFacility>();
-            return container;
         }
     }
 }

--- a/StatsDownload/StatsDownload.TestHarness/ITestHarnessStatsDownloadSettings.cs
+++ b/StatsDownload/StatsDownload.TestHarness/ITestHarnessStatsDownloadSettings.cs
@@ -1,0 +1,7 @@
+﻿namespace StatsDownload.TestHarness
+{
+    public interface ITestHarnessStatsDownloadSettings
+    {
+        bool Enabled { get; }
+    }
+}

--- a/StatsDownload/StatsDownload.TestHarness/MainForm.cs
+++ b/StatsDownload/StatsDownload.TestHarness/MainForm.cs
@@ -15,20 +15,6 @@
             WindsorContainer.Instance.Register(Component.For<Action<string>>().Instance(Log));
         }
 
-        internal void Log(string message)
-        {
-            if (LoggingTextBox.InvokeRequired)
-            {
-                LoggingTextBox.Invoke(new Action((() => Log(message))));
-            }
-            else
-            {
-                AppendToLog(message);
-                AppendToLog(Environment.NewLine);
-                AppendToLog(Environment.NewLine);
-            }
-        }
-
         private void AppendToLog(string message)
         {
             LoggingTextBox.AppendText(message);
@@ -69,6 +55,20 @@
             await
                 RunActionAsync(
                     () => { CreateFileDownloadServiceAndPerformAction(service => { service.DownloadStatsFile(); }); });
+        }
+
+        internal void Log(string message)
+        {
+            if (LoggingTextBox.InvokeRequired)
+            {
+                LoggingTextBox.Invoke(new Action(() => Log(message)));
+            }
+            else
+            {
+                AppendToLog(message);
+                AppendToLog(Environment.NewLine);
+                AppendToLog(Environment.NewLine);
+            }
         }
 
         private async Task RunActionAsync(Action action)

--- a/StatsDownload/StatsDownload.TestHarness/StatsDownload.TestHarness.csproj
+++ b/StatsDownload/StatsDownload.TestHarness/StatsDownload.TestHarness.csproj
@@ -73,6 +73,7 @@
     <Compile Include="CastleWindsor\DependencyRegistration.cs" />
     <Compile Include="CastleWindsor\DatabaseFactoryComponentSelector.cs" />
     <Compile Include="ITestHarnessSettingsService.cs" />
+    <Compile Include="ITestHarnessStatsDownloadSettings.cs" />
     <Compile Include="MainForm.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -87,6 +88,7 @@
     <Compile Include="TestHarnessSettingsProvider.cs" />
     <Compile Include="TestHarnessLoggingProvider.cs" />
     <Compile Include="TestHarnessOneHundredUsersFilter.cs" />
+    <Compile Include="TestHarnessStatsDownloadDatabaseProvider.cs" />
     <EmbeddedResource Include="MainForm.resx">
       <DependentUpon>MainForm.cs</DependentUpon>
     </EmbeddedResource>

--- a/StatsDownload/StatsDownload.TestHarness/TestHarnessSettingsProvider.cs
+++ b/StatsDownload/StatsDownload.TestHarness/TestHarnessSettingsProvider.cs
@@ -11,7 +11,7 @@
     /// </summary>
     public class TestHarnessSettingsProvider : IDatabaseConnectionSettingsService, IDownloadSettingsService,
         ITestHarnessSettingsService, IEmailSettingsService, IZeroPointUsersFilterSettings, IGoogleUsersFilterSettings,
-        IWhitespaceNameUsersFilterSettings, INoPaymentAddressUsersFilterSettings
+        IWhitespaceNameUsersFilterSettings, INoPaymentAddressUsersFilterSettings, ITestHarnessStatsDownloadSettings
     {
         public int? GetCommandTimeout()
         {
@@ -106,6 +106,8 @@
         {
             return GetBoolConfig("DisableSecureFilePayload");
         }
+
+        bool ITestHarnessStatsDownloadSettings.Enabled => GetBoolConfig("EnableTestingSqlExceptionDuringAddUsers");
 
         bool IWhitespaceNameUsersFilterSettings.Enabled => GetBoolConfig("EnableWhitespaceNameUsersFilter");
 

--- a/StatsDownload/StatsDownload.TestHarness/TestHarnessSettingsProvider.cs
+++ b/StatsDownload/StatsDownload.TestHarness/TestHarnessSettingsProvider.cs
@@ -107,7 +107,7 @@
             return GetBoolConfig("DisableSecureFilePayload");
         }
 
-        bool ITestHarnessStatsDownloadSettings.Enabled => GetBoolConfig("EnableTestingSqlExceptionDuringAddUsers");
+        bool ITestHarnessStatsDownloadSettings.Enabled => GetBoolConfig("EnableSqlExceptionDuringAddUsersTest");
 
         bool IWhitespaceNameUsersFilterSettings.Enabled => GetBoolConfig("EnableWhitespaceNameUsersFilter");
 

--- a/StatsDownload/StatsDownload.TestHarness/TestHarnessStatsDownloadDatabaseProvider.cs
+++ b/StatsDownload/StatsDownload.TestHarness/TestHarnessStatsDownloadDatabaseProvider.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Data.Common;
     using System.Data.SqlTypes;
     using System.Linq;
     using Core.Interfaces;
@@ -18,6 +19,16 @@
         {
             this.innerService = innerService;
             this.settings = settings;
+        }
+
+        public void Rollback(DbTransaction transaction)
+        {
+            innerService.Rollback(transaction);
+        }
+
+        public void Commit(DbTransaction transaction)
+        {
+            innerService.Commit(transaction);
         }
 
         public void FileDownloadError(FileDownloadResult fileDownloadResult)
@@ -40,9 +51,10 @@
             return innerService.IsAvailable();
         }
 
-        public void AddUsers(int downloadId, IEnumerable<UserData> usersData, IEnumerable<FailedUserData> failedUsers)
+        public void AddUsers(DbTransaction transaction, int downloadId, IEnumerable<UserData> usersData,
+            IEnumerable<FailedUserData> failedUsers)
         {
-            innerService.AddUsers(downloadId, ModifiedUsers(usersData), failedUsers);
+            innerService.AddUsers(transaction, downloadId, ModifiedUsers(usersData), failedUsers);
         }
 
         public IEnumerable<int> GetDownloadsReadyForUpload()
@@ -55,9 +67,9 @@
             return innerService.GetFileData(downloadId);
         }
 
-        public void StartStatsUpload(int downloadId)
+        public DbTransaction StartStatsUpload(int downloadId)
         {
-            innerService.StartStatsUpload(downloadId);
+            return innerService.StartStatsUpload(downloadId);
         }
 
         public void StatsUploadError(StatsUploadResult statsUploadResult)
@@ -65,9 +77,9 @@
             innerService.StatsUploadError(statsUploadResult);
         }
 
-        public void StatsUploadFinished(int downloadId, DateTime downloadDateTime)
+        public void StatsUploadFinished(DbTransaction transaction, int downloadId, DateTime downloadDateTime)
         {
-            innerService.StatsUploadFinished(downloadId, downloadDateTime);
+            innerService.StatsUploadFinished(transaction, downloadId, downloadDateTime);
         }
 
         public void NewFileDownloadStarted(FilePayload filePayload)

--- a/StatsDownload/StatsDownload.TestHarness/TestHarnessStatsDownloadDatabaseProvider.cs
+++ b/StatsDownload/StatsDownload.TestHarness/TestHarnessStatsDownloadDatabaseProvider.cs
@@ -1,0 +1,96 @@
+﻿namespace StatsDownload.TestHarness
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Data.SqlTypes;
+    using System.Linq;
+    using Core.Interfaces;
+    using Core.Interfaces.DataTransfer;
+
+    public class TestHarnessStatsDownloadDatabaseProvider : IStatsDownloadDatabaseService
+    {
+        private readonly IStatsDownloadDatabaseService innerService;
+
+        private readonly ITestHarnessStatsDownloadSettings settings;
+
+        public TestHarnessStatsDownloadDatabaseProvider(IStatsDownloadDatabaseService innerService,
+            ITestHarnessStatsDownloadSettings settings)
+        {
+            this.innerService = innerService;
+            this.settings = settings;
+        }
+
+        public void FileDownloadError(FileDownloadResult fileDownloadResult)
+        {
+            innerService.FileDownloadError(fileDownloadResult);
+        }
+
+        public void FileDownloadFinished(FilePayload filePayload)
+        {
+            innerService.FileDownloadFinished(filePayload);
+        }
+
+        public DateTime GetLastFileDownloadDateTime()
+        {
+            return innerService.GetLastFileDownloadDateTime();
+        }
+
+        public bool IsAvailable()
+        {
+            return innerService.IsAvailable();
+        }
+
+        public void AddUsers(int downloadId, IEnumerable<UserData> usersData, IEnumerable<FailedUserData> failedUsers)
+        {
+            innerService.AddUsers(downloadId, ModifiedUsers(usersData), failedUsers);
+        }
+
+        public IEnumerable<int> GetDownloadsReadyForUpload()
+        {
+            return innerService.GetDownloadsReadyForUpload();
+        }
+
+        public string GetFileData(int downloadId)
+        {
+            return innerService.GetFileData(downloadId);
+        }
+
+        public void StartStatsUpload(int downloadId)
+        {
+            innerService.StartStatsUpload(downloadId);
+        }
+
+        public void StatsUploadError(StatsUploadResult statsUploadResult)
+        {
+            innerService.StatsUploadError(statsUploadResult);
+        }
+
+        public void StatsUploadFinished(int downloadId, DateTime downloadDateTime)
+        {
+            innerService.StatsUploadFinished(downloadId, downloadDateTime);
+        }
+
+        public void NewFileDownloadStarted(FilePayload filePayload)
+        {
+            innerService.NewFileDownloadStarted(filePayload);
+        }
+
+        public void UpdateToLatest()
+        {
+            innerService.UpdateToLatest();
+        }
+
+        private IEnumerable<UserData> ModifiedUsers(IEnumerable<UserData> usersData)
+        {
+            for (var index = 0; index < usersData.Count(); index++)
+            {
+                if (settings.Enabled && index == 2)
+                {
+                    throw new SqlTypeException("Mocking an exception being thrown during the add users.");
+                }
+
+                yield return usersData.ElementAt(index);
+            }
+        }
+    }
+}

--- a/StatsDownload/StatsDownload.sln.DotSettings
+++ b/StatsDownload/StatsDownload.sln.DotSettings
@@ -220,6 +220,7 @@
     &lt;/Entry&gt;&#xD;
     &lt;Entry DisplayName="All other members"&gt;&#xD;
       &lt;Entry.SortBy&gt;&#xD;
+        &lt;Access /&gt;&#xD;
         &lt;Name /&gt;&#xD;
       &lt;/Entry.SortBy&gt;&#xD;
     &lt;/Entry&gt;&#xD;

--- a/StatsDownload/StatsDownload.sln.DotSettings
+++ b/StatsDownload/StatsDownload.sln.DotSettings
@@ -79,7 +79,7 @@
       &lt;/Entry.SortBy&gt;&#xD;
     &lt;/Entry&gt;&#xD;
     &lt;Entry DisplayName="All other members" /&gt;&#xD;
-    &lt;Entry Priority="100" DisplayName="Test Methods"&gt;&#xD;
+    &lt;Entry DisplayName="Test Methods" Priority="100"&gt;&#xD;
       &lt;Entry.Match&gt;&#xD;
         &lt;And&gt;&#xD;
           &lt;Kind Is="Method" /&gt;&#xD;
@@ -119,7 +119,7 @@
         &lt;/And&gt;&#xD;
       &lt;/Entry.Match&gt;&#xD;
     &lt;/Entry&gt;&#xD;
-    &lt;Entry Priority="100" DisplayName="Test Methods"&gt;&#xD;
+    &lt;Entry DisplayName="Test Methods" Priority="100"&gt;&#xD;
       &lt;Entry.Match&gt;&#xD;
         &lt;And&gt;&#xD;
           &lt;Kind Is="Method" /&gt;&#xD;
@@ -136,7 +136,7 @@
     &lt;Entry DisplayName="All other members" /&gt;&#xD;
   &lt;/TypePattern&gt;&#xD;
   &lt;TypePattern DisplayName="Default Pattern"&gt;&#xD;
-    &lt;Entry Priority="100" DisplayName="Public Delegates"&gt;&#xD;
+    &lt;Entry DisplayName="Public Delegates" Priority="100"&gt;&#xD;
       &lt;Entry.Match&gt;&#xD;
         &lt;And&gt;&#xD;
           &lt;Access Is="Public" /&gt;&#xD;
@@ -147,7 +147,7 @@
         &lt;Name /&gt;&#xD;
       &lt;/Entry.SortBy&gt;&#xD;
     &lt;/Entry&gt;&#xD;
-    &lt;Entry Priority="100" DisplayName="Public Enums"&gt;&#xD;
+    &lt;Entry DisplayName="Public Enums" Priority="100"&gt;&#xD;
       &lt;Entry.Match&gt;&#xD;
         &lt;And&gt;&#xD;
           &lt;Access Is="Public" /&gt;&#xD;
@@ -169,7 +169,8 @@
         &lt;/Or&gt;&#xD;
       &lt;/Entry.Match&gt;&#xD;
       &lt;Entry.SortBy&gt;&#xD;
-        &lt;Kind Order="Constant Field" /&gt;&#xD;
+        &lt;Kind Is="Member" /&gt;&#xD;
+        &lt;Name /&gt;&#xD;
       &lt;/Entry.SortBy&gt;&#xD;
     &lt;/Entry&gt;&#xD;
     &lt;Entry DisplayName="Fields"&gt;&#xD;
@@ -192,6 +193,7 @@
       &lt;/Entry.Match&gt;&#xD;
       &lt;Entry.SortBy&gt;&#xD;
         &lt;Static /&gt;&#xD;
+        &lt;Name /&gt;&#xD;
       &lt;/Entry.SortBy&gt;&#xD;
     &lt;/Entry&gt;&#xD;
     &lt;Entry DisplayName="Properties, Indexers"&gt;&#xD;
@@ -201,8 +203,11 @@
           &lt;Kind Is="Indexer" /&gt;&#xD;
         &lt;/Or&gt;&#xD;
       &lt;/Entry.Match&gt;&#xD;
+      &lt;Entry.SortBy&gt;&#xD;
+        &lt;Name /&gt;&#xD;
+      &lt;/Entry.SortBy&gt;&#xD;
     &lt;/Entry&gt;&#xD;
-    &lt;Entry Priority="100" DisplayName="Interface Implementations"&gt;&#xD;
+    &lt;Entry DisplayName="Interface Implementations" Priority="100"&gt;&#xD;
       &lt;Entry.Match&gt;&#xD;
         &lt;And&gt;&#xD;
           &lt;Kind Is="Member" /&gt;&#xD;
@@ -213,11 +218,18 @@
         &lt;ImplementsInterface Immediate="True" /&gt;&#xD;
       &lt;/Entry.SortBy&gt;&#xD;
     &lt;/Entry&gt;&#xD;
-    &lt;Entry DisplayName="All other members" /&gt;&#xD;
+    &lt;Entry DisplayName="All other members"&gt;&#xD;
+      &lt;Entry.SortBy&gt;&#xD;
+        &lt;Name /&gt;&#xD;
+      &lt;/Entry.SortBy&gt;&#xD;
+    &lt;/Entry&gt;&#xD;
     &lt;Entry DisplayName="Nested Types"&gt;&#xD;
       &lt;Entry.Match&gt;&#xD;
         &lt;Kind Is="Type" /&gt;&#xD;
       &lt;/Entry.Match&gt;&#xD;
+      &lt;Entry.SortBy&gt;&#xD;
+        &lt;Name /&gt;&#xD;
+      &lt;/Entry.SortBy&gt;&#xD;
     &lt;/Entry&gt;&#xD;
   &lt;/TypePattern&gt;&#xD;
 &lt;/Patterns&gt;</s:String>


### PR DESCRIPTION
So the bug 22 is more complex with having to retry the connection and some other possible scenarios. Instead I ensured the stats upload is all or nothing. The file is uploaded, rolled back and updated to rejected, or rolled back and left in ready-for-upload status.