### PR TITLE
Add logging when error during stats upload

### DIFF
--- a/StatsDownload/StatsDownload.Core.Interfaces/DataTransfer/StatsUploadResult.cs
+++ b/StatsDownload/StatsDownload.Core.Interfaces/DataTransfer/StatsUploadResult.cs
@@ -1,36 +1,27 @@
 ﻿namespace StatsDownload.Core.Interfaces.DataTransfer
 {
-    using System;
     using Enums;
 
     public class StatsUploadResult
     {
         public StatsUploadResult()
-            : this(true, 0, FailedReason.None, null)
+            : this(true, 0, FailedReason.None)
         {
         }
 
         public StatsUploadResult(int downloadId, FailedReason failedReason)
-            : this(false, downloadId, failedReason, null)
+            : this(false, downloadId, failedReason)
         {
         }
 
-        public StatsUploadResult(int downloadId, FailedReason failedReason, Exception exception)
-            : this(false, downloadId, failedReason, exception)
-        {
-        }
-
-        private StatsUploadResult(bool success, int downloadId, FailedReason failedReason, Exception exception)
+        private StatsUploadResult(bool success, int downloadId, FailedReason failedReason)
         {
             Success = success;
             DownloadId = downloadId;
             FailedReason = failedReason;
-            Exception = exception;
         }
 
         public int DownloadId { get; }
-
-        public Exception Exception { get; }
 
         public FailedReason FailedReason { get; }
 

--- a/StatsDownload/StatsDownload.Core.Interfaces/DataTransfer/StatsUploadResult.cs
+++ b/StatsDownload/StatsDownload.Core.Interfaces/DataTransfer/StatsUploadResult.cs
@@ -1,27 +1,36 @@
 ﻿namespace StatsDownload.Core.Interfaces.DataTransfer
 {
+    using System;
     using Enums;
 
     public class StatsUploadResult
     {
         public StatsUploadResult()
-            : this(true, 0, FailedReason.None)
+            : this(true, 0, FailedReason.None, null)
         {
         }
 
         public StatsUploadResult(int downloadId, FailedReason failedReason)
-            : this(false, downloadId, failedReason)
+            : this(false, downloadId, failedReason, null)
         {
         }
 
-        private StatsUploadResult(bool success, int downloadId, FailedReason failedReason)
+        public StatsUploadResult(int downloadId, FailedReason failedReason, Exception exception)
+            : this(false, downloadId, failedReason, exception)
+        {
+        }
+
+        private StatsUploadResult(bool success, int downloadId, FailedReason failedReason, Exception exception)
         {
             Success = success;
             DownloadId = downloadId;
             FailedReason = failedReason;
+            Exception = exception;
         }
 
         public int DownloadId { get; }
+
+        public Exception Exception { get; }
 
         public FailedReason FailedReason { get; }
 

--- a/StatsDownload/StatsDownload.Core.Interfaces/Enums/FailedReason.cs
+++ b/StatsDownload/StatsDownload.Core.Interfaces/Enums/FailedReason.cs
@@ -16,6 +16,8 @@
 
         InvalidStatsFileUpload,
 
+        StatsUploadTimeout,
+
         UnexpectedException
     }
 }

--- a/StatsDownload/StatsDownload.Core.Tests/TestErrorMessageProvider.cs
+++ b/StatsDownload/StatsDownload.Core.Tests/TestErrorMessageProvider.cs
@@ -115,6 +115,16 @@
         }
 
         [Test]
+        public void GetErrorMessage_WhenStatsUploadTimeout_ReturnsStatsUploadTimeoutMessage()
+        {
+            string actual = systemUnderTest.GetErrorMessage(FailedReason.StatsUploadTimeout);
+
+            Assert.That(actual,
+                Is.EqualTo(
+                    "There was a problem uploading the file payload. There was a timeout when uploading the stats and the file has been marked rejected. If a timeout occurs again, then you can try increasing the configurable command timeout."));
+        }
+
+        [Test]
         public void GetErrorMessage_WhenUnexpectedException_ReturnsUnexpectedExceptionMessage()
         {
             string actual = systemUnderTest.GetErrorMessage(FailedReason.UnexpectedException, new FilePayload());

--- a/StatsDownload/StatsDownload.Core.Tests/TestStatsUploadProvider.cs
+++ b/StatsDownload/StatsDownload.Core.Tests/TestStatsUploadProvider.cs
@@ -150,18 +150,15 @@
         }
 
         [Test]
-        public void UploadStatsFiles_WhenExceptionThrown_ResultUnexpectedException()
+        public void UploadStatsFiles_WhenExceptionThrown_ResultInvalidStatFileData()
         {
-            var exception = new Exception();
-            statsFileParserServiceMock.Parse(Arg.Any<string>()).Throws(exception);
+            statsFileParserServiceMock.Parse(Arg.Any<string>()).Throws(new Exception());
 
             StatsUploadResults actual = InvokeUploadStatsFiles();
 
             Assert.That(actual.UploadResults.ElementAt(0).DownloadId, Is.EqualTo(1));
             Assert.That(actual.UploadResults.ElementAt(0).FailedReason,
                 Is.EqualTo(FailedReason.UnexpectedException));
-            Assert.That(actual.UploadResults.ElementAt(0).Exception,
-                Is.EqualTo(exception));
         }
 
         [Test]

--- a/StatsDownload/StatsDownload.Core.Tests/TestStatsUploadProvider.cs
+++ b/StatsDownload/StatsDownload.Core.Tests/TestStatsUploadProvider.cs
@@ -150,15 +150,18 @@
         }
 
         [Test]
-        public void UploadStatsFiles_WhenExceptionThrown_ResultInvalidStatFileData()
+        public void UploadStatsFiles_WhenExceptionThrown_ResultUnexpectedException()
         {
-            statsFileParserServiceMock.Parse(Arg.Any<string>()).Throws(new Exception());
+            var exception = new Exception();
+            statsFileParserServiceMock.Parse(Arg.Any<string>()).Throws(exception);
 
             StatsUploadResults actual = InvokeUploadStatsFiles();
 
             Assert.That(actual.UploadResults.ElementAt(0).DownloadId, Is.EqualTo(1));
             Assert.That(actual.UploadResults.ElementAt(0).FailedReason,
                 Is.EqualTo(FailedReason.UnexpectedException));
+            Assert.That(actual.UploadResults.ElementAt(0).Exception,
+                Is.EqualTo(exception));
         }
 
         [Test]

--- a/StatsDownload/StatsDownload.Core.Tests/TestStatsUploadProvider.cs
+++ b/StatsDownload/StatsDownload.Core.Tests/TestStatsUploadProvider.cs
@@ -104,6 +104,18 @@
         }
 
         [Test]
+        public void UploadStatsFiles_WhenDatabaseTimeoutExceptionThrown_ReturnsDatabaseTimeoutResult()
+        {
+            SetUpWhenDatabaseTimeoutExceptionThrown();
+
+            StatsUploadResults actual = InvokeUploadStatsFiles();
+
+            Assert.That(actual.UploadResults.ElementAt(0).DownloadId, Is.EqualTo(1));
+            Assert.That(actual.UploadResults.ElementAt(0).FailedReason,
+                Is.EqualTo(FailedReason.StatsUploadTimeout));
+        }
+
+        [Test]
         public void UploadStatsFiles_WhenDataStoreIsNotAvailable_LogsResult()
         {
             SetUpWhenDataStoreIsNotAvailable();
@@ -371,6 +383,12 @@
                 statsUploadEmailService);
         }
 
+        private void SetUpWhenDatabaseTimeoutExceptionThrown()
+        {
+            var exception = new TestDbTimeoutException();
+            statsUploadDatabaseServiceMock.GetFileData(1).Throws(exception);
+        }
+
         private void SetUpWhenDataStoreIsNotAvailable()
         {
             statsUploadDatabaseServiceMock.IsAvailable().Returns(false);
@@ -387,6 +405,13 @@
         {
             var exception = new InvalidStatsFileException();
             statsFileParserServiceMock.Parse(Arg.Any<string>()).Throws(exception);
+        }
+
+        private class TestDbTimeoutException : DbException
+        {
+            public TestDbTimeoutException() : base("Mock timeout exception", -2146232060)
+            {
+            }
         }
     }
 }

--- a/StatsDownload/StatsDownload.Core/Implementations/ErrorMessageProvider.cs
+++ b/StatsDownload/StatsDownload.Core/Implementations/ErrorMessageProvider.cs
@@ -63,6 +63,12 @@
                        + " The file failed validation; check the logs for more information. If this problem occurs again, then you should contact your technical advisor to review the logs and failed uploads.";
             }
 
+            if (failedReason == FailedReason.StatsUploadTimeout)
+            {
+                return StatsUploadFailBodyStart +
+                       " There was a timeout when uploading the stats and the file has been marked rejected. If a timeout occurs again, then you can try increasing the configurable command timeout.";
+            }
+
             if (failedReason == FailedReason.UnexpectedException)
             {
                 return FileDownloadFailBodyStart + " Check the log for more information.";

--- a/StatsDownload/StatsDownload.Core/Implementations/StatsUploadProvider.cs
+++ b/StatsDownload/StatsDownload.Core/Implementations/StatsUploadProvider.cs
@@ -118,9 +118,10 @@
             loggingService.LogVerbose(message);
         }
 
-        private StatsUploadResult NewFailedStatsUploadResult(int downloadId, FailedReason failedReason)
+        private StatsUploadResult NewFailedStatsUploadResult(int downloadId, FailedReason failedReason,
+            Exception exception)
         {
-            return new StatsUploadResult(downloadId, failedReason);
+            return new StatsUploadResult(downloadId, failedReason, exception);
         }
 
         private void UploadStatsFile(List<StatsUploadResult> statsUploadResults, int downloadId)
@@ -144,7 +145,8 @@
             {
                 statsUploadDatabaseService.Rollback(transaction);
                 FailedReason failedReason = GetFailedReason(exception);
-                StatsUploadResult failedStatsUploadResult = NewFailedStatsUploadResult(downloadId, failedReason);
+                StatsUploadResult failedStatsUploadResult =
+                    NewFailedStatsUploadResult(downloadId, failedReason, exception);
                 loggingService.LogResult(failedStatsUploadResult);
                 statsUploadEmailService.SendEmail(failedStatsUploadResult);
                 statsUploadDatabaseService.StatsUploadError(failedStatsUploadResult);

--- a/StatsDownload/StatsDownload.Core/Implementations/StatsUploadProvider.cs
+++ b/StatsDownload/StatsDownload.Core/Implementations/StatsUploadProvider.cs
@@ -118,10 +118,9 @@
             loggingService.LogVerbose(message);
         }
 
-        private StatsUploadResult NewFailedStatsUploadResult(int downloadId, FailedReason failedReason,
-            Exception exception)
+        private StatsUploadResult NewFailedStatsUploadResult(int downloadId, FailedReason failedReason)
         {
-            return new StatsUploadResult(downloadId, failedReason, exception);
+            return new StatsUploadResult(downloadId, failedReason);
         }
 
         private void UploadStatsFile(List<StatsUploadResult> statsUploadResults, int downloadId)
@@ -145,8 +144,7 @@
             {
                 statsUploadDatabaseService.Rollback(transaction);
                 FailedReason failedReason = GetFailedReason(exception);
-                StatsUploadResult failedStatsUploadResult =
-                    NewFailedStatsUploadResult(downloadId, failedReason, exception);
+                StatsUploadResult failedStatsUploadResult = NewFailedStatsUploadResult(downloadId, failedReason);
                 loggingService.LogResult(failedStatsUploadResult);
                 statsUploadEmailService.SendEmail(failedStatsUploadResult);
                 statsUploadDatabaseService.StatsUploadError(failedStatsUploadResult);

--- a/StatsDownload/StatsDownload.Core/Implementations/StatsUploadProvider.cs
+++ b/StatsDownload/StatsDownload.Core/Implementations/StatsUploadProvider.cs
@@ -94,6 +94,11 @@
                 return FailedReason.InvalidStatsFileUpload;
             }
 
+            if (exception is DbException dbException && dbException.ErrorCode == -2146232060)
+            {
+                return FailedReason.StatsUploadTimeout;
+            }
+
             return FailedReason.UnexpectedException;
         }
 

--- a/StatsDownload/StatsDownload.Core/Implementations/StatsUploadProvider.cs
+++ b/StatsDownload/StatsDownload.Core/Implementations/StatsUploadProvider.cs
@@ -146,6 +146,7 @@
                 FailedReason failedReason = GetFailedReason(exception);
                 StatsUploadResult failedStatsUploadResult = NewFailedStatsUploadResult(downloadId, failedReason);
                 loggingService.LogResult(failedStatsUploadResult);
+                loggingService.LogException(exception);
                 statsUploadEmailService.SendEmail(failedStatsUploadResult);
                 statsUploadDatabaseService.StatsUploadError(failedStatsUploadResult);
                 statsUploadResults.Add(failedStatsUploadResult);

--- a/StatsDownload/StatsDownload.Email/EmailProvider.cs
+++ b/StatsDownload/StatsDownload.Email/EmailProvider.cs
@@ -48,15 +48,17 @@
 
             try
             {
+                sb.AppendLine("Attempting to send email:");
+                sb.AppendLine($"Subject: {subject}");
+                sb.Append($"Body: {body}");
+
                 MailAddress fromAddress = NewMailAddress();
 
                 IEnumerable<string> receivers = ParseReceivers(settingsService.GetReceivers());
 
                 using (SmtpClient smtpClient = NewSmtpClient(sb, fromAddress))
                 {
-                    sb.AppendLine("Sending email:");
-                    sb.AppendLine($"Subject: {subject}");
-                    sb.AppendLine($"Body: {body}");
+                    sb.AppendLine();
                     sb.AppendLine();
 
                     foreach (string address in receivers)

--- a/StatsDownload/StatsDownload.sln.DotSettings
+++ b/StatsDownload/StatsDownload.sln.DotSettings
@@ -133,7 +133,12 @@
         &lt;Name /&gt;&#xD;
       &lt;/Entry.SortBy&gt;&#xD;
     &lt;/Entry&gt;&#xD;
-    &lt;Entry DisplayName="All other members" /&gt;&#xD;
+    &lt;Entry DisplayName="All other members"&gt;&#xD;
+      &lt;Entry.SortBy&gt;&#xD;
+        &lt;Name /&gt;&#xD;
+        &lt;Kind Is="Member" /&gt;&#xD;
+      &lt;/Entry.SortBy&gt;&#xD;
+    &lt;/Entry&gt;&#xD;
   &lt;/TypePattern&gt;&#xD;
   &lt;TypePattern DisplayName="Default Pattern"&gt;&#xD;
     &lt;Entry DisplayName="Public Delegates" Priority="100"&gt;&#xD;


### PR DESCRIPTION
Made it so that the exception would be logged when one is thrown during the stats upload process.
Updated the email provider to show the email subject and body (easier for testing to see message without having to setup a SMTP provider)
Added a new failed reason type to capture when a timeout occurs and give a useful message here