### PR TITLE
Add logging when error during stats upload

### DIFF
--- a/Database/FoldingCoinStoredProceduresV1.sql
+++ b/Database/FoldingCoinStoredProceduresV1.sql
@@ -248,7 +248,7 @@ BEGIN
 
 	BEGIN TRY
 		BEGIN TRANSACTION
-			SELECT @FileDownloadErrorStatusId = FoldingCoin.GetfileDownloadErrorStatusId();
+			SELECT @FileDownloadErrorStatusId = [FoldingCoin].GetFileDownloadErrorStatusId();
 
 			UPDATE [FoldingCoin].[Downloads] 
 			SET StatusId = @FileDownloadErrorStatusId

--- a/StatsDownload/StatsDownload.Core.Interfaces/DataTransfer/StatsUploadResult.cs
+++ b/StatsDownload/StatsDownload.Core.Interfaces/DataTransfer/StatsUploadResult.cs
@@ -1,36 +1,27 @@
 ﻿namespace StatsDownload.Core.Interfaces.DataTransfer
 {
-    using System;
     using Enums;
 
     public class StatsUploadResult
     {
         public StatsUploadResult()
-            : this(true, 0, FailedReason.None, null)
+            : this(true, 0, FailedReason.None)
         {
         }
 
         public StatsUploadResult(int downloadId, FailedReason failedReason)
-            : this(false, downloadId, failedReason, null)
+            : this(false, downloadId, failedReason)
         {
         }
 
-        public StatsUploadResult(int downloadId, FailedReason failedReason, Exception exception)
-            : this(false, downloadId, failedReason, exception)
-        {
-        }
-
-        private StatsUploadResult(bool success, int downloadId, FailedReason failedReason, Exception exception)
+        private StatsUploadResult(bool success, int downloadId, FailedReason failedReason)
         {
             Success = success;
             DownloadId = downloadId;
             FailedReason = failedReason;
-            Exception = exception;
         }
 
         public int DownloadId { get; }
-
-        public Exception Exception { get; }
 
         public FailedReason FailedReason { get; }
 

--- a/StatsDownload/StatsDownload.Core.Interfaces/DataTransfer/StatsUploadResult.cs
+++ b/StatsDownload/StatsDownload.Core.Interfaces/DataTransfer/StatsUploadResult.cs
@@ -1,27 +1,36 @@
 ﻿namespace StatsDownload.Core.Interfaces.DataTransfer
 {
+    using System;
     using Enums;
 
     public class StatsUploadResult
     {
         public StatsUploadResult()
-            : this(true, 0, FailedReason.None)
+            : this(true, 0, FailedReason.None, null)
         {
         }
 
         public StatsUploadResult(int downloadId, FailedReason failedReason)
-            : this(false, downloadId, failedReason)
+            : this(false, downloadId, failedReason, null)
         {
         }
 
-        private StatsUploadResult(bool success, int downloadId, FailedReason failedReason)
+        public StatsUploadResult(int downloadId, FailedReason failedReason, Exception exception)
+            : this(false, downloadId, failedReason, exception)
+        {
+        }
+
+        private StatsUploadResult(bool success, int downloadId, FailedReason failedReason, Exception exception)
         {
             Success = success;
             DownloadId = downloadId;
             FailedReason = failedReason;
+            Exception = exception;
         }
 
         public int DownloadId { get; }
+
+        public Exception Exception { get; }
 
         public FailedReason FailedReason { get; }
 

--- a/StatsDownload/StatsDownload.Core.Interfaces/Enums/FailedReason.cs
+++ b/StatsDownload/StatsDownload.Core.Interfaces/Enums/FailedReason.cs
@@ -16,6 +16,8 @@
 
         InvalidStatsFileUpload,
 
+        StatsUploadTimeout,
+
         UnexpectedException
     }
 }

--- a/StatsDownload/StatsDownload.Core.Interfaces/IDatabaseConnectionService.cs
+++ b/StatsDownload/StatsDownload.Core.Interfaces/IDatabaseConnectionService.cs
@@ -9,19 +9,24 @@
     {
         ConnectionState ConnectionState { get; }
 
-        DbCommand CreateDbCommand();
+        void Close();
 
-        DbTransaction CreateTransaction();
+        DbCommand CreateDbCommand();
 
         DbParameter CreateParameter(string parameterName, DbType dbType, ParameterDirection direction);
 
         DbParameter CreateParameter(string parameterName, DbType dbType, ParameterDirection direction, int size);
+
+        DbTransaction CreateTransaction();
 
         DbDataReader ExecuteReader(string commandText);
 
         object ExecuteScalar(string commandText);
 
         int ExecuteStoredProcedure(string storedProcedure, IEnumerable<DbParameter> parameters);
+
+        int ExecuteStoredProcedure(DbTransaction transaction, string storedProcedure,
+            IEnumerable<DbParameter> parameters);
 
         int ExecuteStoredProcedure(string storedProcedure);
 

--- a/StatsDownload/StatsDownload.Core.Interfaces/IStatsUploadDatabaseService.cs
+++ b/StatsDownload/StatsDownload.Core.Interfaces/IStatsUploadDatabaseService.cs
@@ -2,11 +2,15 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Data.Common;
     using DataTransfer;
 
     public interface IStatsUploadDatabaseService
     {
-        void AddUsers(int downloadId, IEnumerable<UserData> usersData, IEnumerable<FailedUserData> failedUsers);
+        void AddUsers(DbTransaction transaction, int downloadId, IEnumerable<UserData> usersData,
+            IEnumerable<FailedUserData> failedUsers);
+
+        void Commit(DbTransaction transaction);
 
         IEnumerable<int> GetDownloadsReadyForUpload();
 
@@ -14,10 +18,12 @@
 
         bool IsAvailable();
 
-        void StartStatsUpload(int downloadId);
+        void Rollback(DbTransaction transaction);
+
+        DbTransaction StartStatsUpload(int downloadId);
 
         void StatsUploadError(StatsUploadResult statsUploadResult);
 
-        void StatsUploadFinished(int downloadId, DateTime downloadDateTime);
+        void StatsUploadFinished(DbTransaction transaction, int downloadId, DateTime downloadDateTime);
     }
 }

--- a/StatsDownload/StatsDownload.Core.Tests/TestErrorMessageProvider.cs
+++ b/StatsDownload/StatsDownload.Core.Tests/TestErrorMessageProvider.cs
@@ -115,6 +115,16 @@
         }
 
         [Test]
+        public void GetErrorMessage_WhenStatsUploadTimeout_ReturnsStatsUploadTimeoutMessage()
+        {
+            string actual = systemUnderTest.GetErrorMessage(FailedReason.StatsUploadTimeout);
+
+            Assert.That(actual,
+                Is.EqualTo(
+                    "There was a problem uploading the file payload. There was a timeout when uploading the stats and the file has been marked rejected. If a timeout occurs again, then you can try increasing the configurable command timeout."));
+        }
+
+        [Test]
         public void GetErrorMessage_WhenUnexpectedException_ReturnsUnexpectedExceptionMessage()
         {
             string actual = systemUnderTest.GetErrorMessage(FailedReason.UnexpectedException, new FilePayload());

--- a/StatsDownload/StatsDownload.Core.Tests/TestErrorMessageProvider.cs
+++ b/StatsDownload/StatsDownload.Core.Tests/TestErrorMessageProvider.cs
@@ -137,7 +137,7 @@
         [Test]
         public void GetErrorMessage_WhenUnknownRejectionReason_ReturnsEmptyString()
         {
-            var actual = systemUnderTest.GetErrorMessage(new FailedUserData(0, string.Empty,
+            string actual = systemUnderTest.GetErrorMessage(new FailedUserData(0, string.Empty,
                 (RejectionReason) Enum.Parse(typeof (RejectionReason), "-1")));
 
             Assert.IsEmpty(actual);

--- a/StatsDownload/StatsDownload.Core.Tests/TestFileDownloadProvider.cs
+++ b/StatsDownload/StatsDownload.Core.Tests/TestFileDownloadProvider.cs
@@ -154,13 +154,13 @@
 
             InvokeDownloadFile();
 
-            Received.InOrder((() =>
+            Received.InOrder(() =>
             {
                 loggingServiceMock.LogVerbose("DownloadStatsFile Invoked");
                 fileDownloadDatabaseServiceMock.IsAvailable();
                 loggingServiceMock.LogResult(Arg.Any<FileDownloadResult>());
                 loggingServiceMock.LogException(expected);
-            }));
+            });
         }
 
         [Test]
@@ -219,11 +219,11 @@
 
             InvokeDownloadFile();
 
-            Received.InOrder((() =>
+            Received.InOrder(() =>
             {
                 loggingServiceMock.LogResult(Arg.Any<FileDownloadResult>());
                 loggingServiceMock.LogException(exception);
-            }));
+            });
         }
 
         [Test]
@@ -287,11 +287,11 @@
 
             InvokeDownloadFile();
 
-            Received.InOrder((() =>
+            Received.InOrder(() =>
             {
                 loggingServiceMock.LogResult(Arg.Any<FileDownloadResult>());
                 loggingServiceMock.LogException(exception);
-            }));
+            });
         }
 
         [Test]
@@ -340,7 +340,7 @@
         {
             InvokeDownloadFile();
 
-            Received.InOrder((() =>
+            Received.InOrder(() =>
             {
                 loggingServiceMock.LogVerbose("DownloadStatsFile Invoked");
                 fileDownloadDatabaseServiceMock.IsAvailable();
@@ -356,7 +356,7 @@
                 filePayloadUploadServiceMock.UploadFile(Arg.Any<FilePayload>());
                 resourceCleanupServiceMock.Cleanup(Arg.Any<FileDownloadResult>());
                 loggingServiceMock.LogResult(Arg.Any<FileDownloadResult>());
-            }));
+            });
         }
 
         [Test]

--- a/StatsDownload/StatsDownload.Core.Tests/TestGoogleUsersFilter.cs
+++ b/StatsDownload/StatsDownload.Core.Tests/TestGoogleUsersFilter.cs
@@ -39,7 +39,7 @@
             var expected = new ParseResults(downloadDateTime, null, null);
             innerServiceMock.Parse("fileData").Returns(expected);
 
-            var actual = systemUnderTest.Parse("fileData");
+            ParseResults actual = systemUnderTest.Parse("fileData");
 
             Assert.That(actual, Is.EqualTo(expected));
         }

--- a/StatsDownload/StatsDownload.Core.Tests/TestNoPaymentAddressUsersFilter.cs
+++ b/StatsDownload/StatsDownload.Core.Tests/TestNoPaymentAddressUsersFilter.cs
@@ -39,7 +39,7 @@
             var expected = new ParseResults(downloadDateTime, null, null);
             innerServiceMock.Parse("fileData").Returns(expected);
 
-            var actual = systemUnderTest.Parse("fileData");
+            ParseResults actual = systemUnderTest.Parse("fileData");
 
             Assert.That(actual, Is.EqualTo(expected));
         }

--- a/StatsDownload/StatsDownload.Core.Tests/TestSecureDownloadProvider.cs
+++ b/StatsDownload/StatsDownload.Core.Tests/TestSecureDownloadProvider.cs
@@ -98,11 +98,11 @@
 
             systemUnderTest.DownloadFile(filePayload);
 
-            Received.InOrder((() =>
+            Received.InOrder(() =>
             {
                 secureFilePayloadServiceMock.EnableSecureFilePayload(filePayload);
                 downloadServiceMock.DownloadFile(filePayload);
-            }));
+            });
         }
 
         [Test]
@@ -144,14 +144,14 @@
 
             systemUnderTest.DownloadFile(filePayload);
 
-            Received.InOrder((() =>
+            Received.InOrder(() =>
             {
                 secureFilePayloadServiceMock.EnableSecureFilePayload(filePayload);
                 downloadServiceMock.DownloadFile(filePayload);
                 loggingServiceMock.LogException(webException);
                 secureFilePayloadServiceMock.DisableSecureFilePayload(filePayload);
                 downloadServiceMock.DownloadFile(filePayload);
-            }));
+            });
         }
 
         private IDownloadService NewSecureDownloadProvider(IDownloadService downloadService,

--- a/StatsDownload/StatsDownload.Core.Tests/TestStatsDownloadDatabaseProvider.cs
+++ b/StatsDownload/StatsDownload.Core.Tests/TestStatsDownloadDatabaseProvider.cs
@@ -115,24 +115,6 @@
         private IStatsDownloadDatabaseService systemUnderTest;
 
         [Test]
-        public void AddUsers_WhenExceptionThrown_RollbackTransaction()
-        {
-            SetUpDatabaseConnectionCreateDbCommandMock(new Action<DbCommand>[]
-            {
-                dbCommand => { throw new Exception(); }
-            });
-
-            DbTransaction transactionMock = Substitute.For<DbTransaction>();
-            databaseConnectionServiceMock.CreateTransaction().Returns(transactionMock);
-
-            Assert.Throws<Exception>(() =>
-                systemUnderTest.AddUsers(1, new List<UserData> { new UserData(), new UserData(), new UserData() },
-                    new List<FailedUserData> { new FailedUserData(), new FailedUserData() }));
-
-            transactionMock.Received(1).Rollback();
-        }
-
-        [Test]
         public void AddUsers_WhenInvoked_AddsUsers()
         {
             DbCommand failedUsersCommand = null;
@@ -145,24 +127,19 @@
                 dbCommand => rebuildIndicesCommand = dbCommand
             });
 
-            DbTransaction transactionMock = Substitute.For<DbTransaction>();
-            databaseConnectionServiceMock.CreateTransaction().Returns(transactionMock);
-
-            systemUnderTest.AddUsers(1, new List<UserData> { new UserData(), new UserData(), new UserData() },
+            systemUnderTest.AddUsers(null, 1, new List<UserData> { new UserData(), new UserData(), new UserData() },
                 new List<FailedUserData> { new FailedUserData(), new FailedUserData() });
 
             Received.InOrder(() =>
             {
                 loggingServiceMock.LogVerbose("AddUsers Invoked");
                 loggingServiceMock.LogVerbose("Database connection was successful");
-                databaseConnectionServiceMock.CreateTransaction();
                 failedUsersCommand.ExecuteNonQuery();
                 failedUsersCommand.ExecuteNonQuery();
                 addUsersCommand.ExecuteNonQuery();
                 rebuildIndicesCommand.ExecuteNonQuery();
                 addUsersCommand.ExecuteNonQuery();
                 addUsersCommand.ExecuteNonQuery();
-                transactionMock.Commit();
             });
         }
 
@@ -174,7 +151,7 @@
             SetUpDatabaseConnectionCreateDbCommandMock(null,
                 new Action<List<DbParameter>>[] { null, parameters => { actualParameters = parameters; } });
 
-            systemUnderTest.AddUsers(1,
+            systemUnderTest.AddUsers(null, 1,
                 new List<UserData>
                 {
                     new UserData("name", 10, 100, 1000)
@@ -225,7 +202,7 @@
             SetUpDatabaseConnectionCreateDbCommandMock(null,
                 new Action<List<DbParameter>>[] { parameters => { actualParameters = parameters; } });
 
-            systemUnderTest.AddUsers(1, null, new[] { failedUserData });
+            systemUnderTest.AddUsers(null, 1, null, new[] { failedUserData });
 
             Assert.That(actualParameters.Count, Is.EqualTo(3));
             Assert.That(actualParameters[0].ParameterName, Is.EqualTo("@DownloadId"));
@@ -255,7 +232,7 @@
                 dbCommand => rebuildIndicesCommand = dbCommand
             });
 
-            systemUnderTest.AddUsers(1, new[] { new UserData(), new UserData() }, null);
+            systemUnderTest.AddUsers(null, 1, new[] { new UserData(), new UserData() }, null);
 
             failedUsersCommand.Received(1).Dispose();
             addUsersCommand.Received(1).Dispose();
@@ -279,7 +256,7 @@
                 users[index] = new UserData();
             }
 
-            systemUnderTest.AddUsers(1, users, null);
+            systemUnderTest.AddUsers(null, 1, users, null);
 
             command.Received(2).ExecuteNonQuery();
         }
@@ -289,7 +266,7 @@
         {
             SetUpDatabaseConnectionCreateDbCommandMock();
 
-            systemUnderTest.AddUsers(0, null, null);
+            systemUnderTest.AddUsers(null, 0, null, null);
 
             databaseConnectionServiceMock.Received(3).CreateDbCommand();
         }
@@ -299,7 +276,7 @@
         {
             SetUpDatabaseConnectionCreateDbCommandMock();
 
-            systemUnderTest.AddUsers(0, null, null);
+            systemUnderTest.AddUsers(null, 0, null, null);
 
             databaseConnectionServiceMock.ReceivedWithAnyArgs(10)
                                          .CreateParameter(null, DbType.AnsiString, ParameterDirection.Input);
@@ -315,10 +292,9 @@
                 dbCommand => command = dbCommand
             });
 
-            DbTransaction transactionMock = Substitute.For<DbTransaction>();
-            databaseConnectionServiceMock.CreateTransaction().Returns(transactionMock);
+            var transactionMock = Substitute.For<DbTransaction>();
 
-            systemUnderTest.AddUsers(1, null, null);
+            systemUnderTest.AddUsers(transactionMock, 1, null, null);
 
             command.Received(1).CommandText = "[FoldingCoin].[AddUserData]";
             command.Received(1).CommandType = CommandType.StoredProcedure;
@@ -331,10 +307,9 @@
             DbCommand command = default(DbCommand);
             SetUpDatabaseConnectionCreateDbCommandMock(new Action<DbCommand>[] { dbCommand => command = dbCommand });
 
-            DbTransaction transactionMock = Substitute.For<DbTransaction>();
-            databaseConnectionServiceMock.CreateTransaction().Returns(transactionMock);
+            var transactionMock = Substitute.For<DbTransaction>();
 
-            systemUnderTest.AddUsers(1, null, null);
+            systemUnderTest.AddUsers(transactionMock, 1, null, null);
 
             command.Received(1).CommandText = "[FoldingCoin].[AddUserRejection]";
             command.Received(1).CommandType = CommandType.StoredProcedure;
@@ -352,10 +327,9 @@
                 dbCommand => command = dbCommand
             });
 
-            DbTransaction transactionMock = Substitute.For<DbTransaction>();
-            databaseConnectionServiceMock.CreateTransaction().Returns(transactionMock);
+            var transactionMock = Substitute.For<DbTransaction>();
 
-            systemUnderTest.AddUsers(1, null, null);
+            systemUnderTest.AddUsers(transactionMock, 1, null, null);
 
             command.Received(1).CommandText = "[FoldingCoin].[RebuildIndices]";
             command.Received(1).CommandType = CommandType.StoredProcedure;
@@ -369,7 +343,7 @@
             SetUpDatabaseConnectionCreateDbCommandMock(null,
                 new Action<List<DbParameter>>[] { null, parameters => { actualParameters = parameters; } });
 
-            systemUnderTest.AddUsers(1,
+            systemUnderTest.AddUsers(null, 1,
                 new List<UserData> { new UserData("name", 10, 100, 1000) { FriendlyName = "friendly" } }, null);
 
             Assert.That(actualParameters.Count, Is.EqualTo(7));
@@ -384,12 +358,22 @@
             SetUpDatabaseConnectionCreateDbCommandMock(null,
                 new Action<List<DbParameter>>[] { null, parameters => { actualParameters = parameters; } });
 
-            systemUnderTest.AddUsers(1,
+            systemUnderTest.AddUsers(null, 1,
                 new List<UserData> { new UserData("name", 10, 100, 1000) { BitcoinAddress = "address" } }, null);
 
             Assert.That(actualParameters.Count, Is.EqualTo(7));
             Assert.That(actualParameters[5].ParameterName, Is.EqualTo("@FriendlyName"));
             Assert.That(actualParameters[5].Value, Is.EqualTo(DBNull.Value));
+        }
+
+        [Test]
+        public void Commit_WhenInvoked_CommitsTransaction()
+        {
+            var transaction = Substitute.For<DbTransaction>();
+
+            systemUnderTest.Commit(transaction);
+
+            transaction.Received(1).Commit();
         }
 
         [Test]
@@ -446,13 +430,13 @@
         {
             InvokeFileDownloadError();
 
-            Received.InOrder((() =>
+            Received.InOrder(() =>
             {
                 loggingServiceMock.LogVerbose("FileDownloadError Invoked");
                 loggingServiceMock.LogVerbose("Database connection was successful");
                 databaseConnectionServiceMock.ExecuteStoredProcedure("[FoldingCoin].[FileDownloadError]",
                     Arg.Any<List<DbParameter>>());
-            }));
+            });
         }
 
         [Test]
@@ -641,12 +625,12 @@
 
             InvokeIsAvailable();
 
-            Received.InOrder((() =>
+            Received.InOrder(() =>
             {
                 loggingServiceMock.LogVerbose("IsAvailable Invoked");
                 databaseConnectionServiceMock.Open();
                 loggingServiceMock.LogVerbose("Database connection was successful");
-            }));
+            });
         }
 
         [Test]
@@ -668,12 +652,12 @@
 
             InvokeIsAvailable();
 
-            Received.InOrder((() =>
+            Received.InOrder(() =>
             {
                 loggingServiceMock.LogVerbose("IsAvailable Invoked");
                 databaseConnectionServiceMock.Open();
                 loggingServiceMock.LogException(expected);
-            }));
+            });
         }
 
         [Test]
@@ -718,13 +702,13 @@
         {
             InvokeNewFileDownloadStarted();
 
-            Received.InOrder((() =>
+            Received.InOrder(() =>
             {
                 loggingServiceMock.LogVerbose("NewFileDownloadStarted Invoked");
                 loggingServiceMock.LogVerbose("Database connection was successful");
                 databaseConnectionServiceMock.ExecuteStoredProcedure("[FoldingCoin].[NewFileDownloadStarted]",
                     Arg.Any<List<DbParameter>>());
-            }));
+            });
         }
 
         [Test]
@@ -771,13 +755,27 @@
         }
 
         [Test]
+        public void Rollback_WhenInvoked_RollsBackTransaction()
+        {
+            var transaction = Substitute.For<DbTransaction>();
+
+            systemUnderTest.Rollback(transaction);
+
+            transaction.Received(1).Rollback();
+        }
+
+        [Test]
         public void StartStatsUpload_WhenInvoked_ParameterIsProvided()
         {
+            var transaction = Substitute.For<DbTransaction>();
+            databaseConnectionServiceMock.CreateTransaction().Returns(transaction);
+
             List<DbParameter> actualParameters = default(List<DbParameter>);
 
             databaseConnectionServiceMock.When(
                                              service =>
-                                                 service.ExecuteStoredProcedure("[FoldingCoin].[StartStatsUpload]",
+                                                 service.ExecuteStoredProcedure(transaction,
+                                                     "[FoldingCoin].[StartStatsUpload]",
                                                      Arg.Any<List<DbParameter>>()))
                                          .Do(callback => { actualParameters = callback.Arg<List<DbParameter>>(); });
 
@@ -791,15 +789,29 @@
         }
 
         [Test]
+        public void StartStatsUpload_WhenInvoked_ReturnsTransaction()
+        {
+            var expected = Substitute.For<DbTransaction>();
+            databaseConnectionServiceMock.CreateTransaction().Returns(expected);
+
+            DbTransaction actual = systemUnderTest.StartStatsUpload(100);
+
+            Assert.That(actual, Is.EqualTo(expected));
+        }
+
+        [Test]
         public void StartStatsUpload_WhenInvoked_StartsStatsUpload()
         {
+            var transaction = Substitute.For<DbTransaction>();
+            databaseConnectionServiceMock.CreateTransaction().Returns(transaction);
+
             systemUnderTest.StartStatsUpload(1);
 
             Received.InOrder(() =>
             {
                 loggingServiceMock.LogVerbose("StartStatsUpload Invoked");
                 loggingServiceMock.LogVerbose("Database connection was successful");
-                databaseConnectionServiceMock.ExecuteStoredProcedure("[FoldingCoin].[StartStatsUpload]",
+                databaseConnectionServiceMock.ExecuteStoredProcedure(transaction, "[FoldingCoin].[StartStatsUpload]",
                     Arg.Any<List<DbParameter>>());
             });
         }
@@ -846,17 +858,20 @@
         [Test]
         public void StatsUploadFinished_WhenInvoked_ParametersAreProvided()
         {
+            var transaction = Substitute.For<DbTransaction>();
+
             List<DbParameter> actualParameters = default(List<DbParameter>);
 
             databaseConnectionServiceMock.When(
                                              service =>
-                                                 service.ExecuteStoredProcedure("[FoldingCoin].[StatsUploadFinished]",
+                                                 service.ExecuteStoredProcedure(transaction,
+                                                     "[FoldingCoin].[StatsUploadFinished]",
                                                      Arg.Any<List<DbParameter>>()))
                                          .Do(callback => { actualParameters = callback.Arg<List<DbParameter>>(); });
 
-            var dateTime = DateTime.UtcNow;
+            DateTime dateTime = DateTime.UtcNow;
 
-            systemUnderTest.StatsUploadFinished(100, dateTime);
+            systemUnderTest.StatsUploadFinished(transaction, 100, dateTime);
 
             Assert.That(actualParameters.Count, Is.EqualTo(2));
             Assert.That(actualParameters[0].ParameterName, Is.EqualTo("@DownloadId"));
@@ -872,15 +887,17 @@
         [Test]
         public void StatsUploadFinished_WhenInvoked_UpdatesStatsUploadToFinished()
         {
-            systemUnderTest.StatsUploadFinished(100, DateTime.Now);
+            var transaction = Substitute.For<DbTransaction>();
 
-            Received.InOrder((() =>
+            systemUnderTest.StatsUploadFinished(transaction, 100, DateTime.Now);
+
+            Received.InOrder(() =>
             {
                 loggingServiceMock.LogVerbose("StatsUploadFinished Invoked");
                 loggingServiceMock.LogVerbose("Database connection was successful");
-                databaseConnectionServiceMock.ExecuteStoredProcedure("[FoldingCoin].[StatsUploadFinished]",
+                databaseConnectionServiceMock.ExecuteStoredProcedure(transaction, "[FoldingCoin].[StatsUploadFinished]",
                     Arg.Any<List<DbParameter>>());
-            }));
+            });
         }
 
         [Test]
@@ -891,13 +908,13 @@
 
             InvokeUpdateToLatest();
 
-            Received.InOrder((() =>
+            Received.InOrder(() =>
             {
                 loggingServiceMock.LogVerbose("UpdateToLatest Invoked");
                 loggingServiceMock.LogVerbose("Database connection was successful");
                 databaseConnectionServiceMock.ExecuteStoredProcedure("[FoldingCoin].[UpdateToLatest]");
                 loggingServiceMock.LogVerbose($"'{NumberOfRowsEffectedExpected}' rows were effected");
-            }));
+            });
         }
 
         private const int NumberOfRowsEffectedExpected = 5;

--- a/StatsDownload/StatsDownload.Core.Tests/TestStatsFileParserProvider.cs
+++ b/StatsDownload/StatsDownload.Core.Tests/TestStatsFileParserProvider.cs
@@ -50,7 +50,7 @@
         public void Parse_WhenInvoked_ReturnsDownloadDateTimeInUTC(string fileData, int year, int month, int day,
             int hour, int minute, int second)
         {
-            var actual = InvokeParse(fileData).DownloadDateTime;
+            DateTime actual = InvokeParse(fileData).DownloadDateTime;
 
             Assert.That(actual, Is.EqualTo(new DateTime(year, month, day, hour, minute, second)));
         }

--- a/StatsDownload/StatsDownload.Core.Tests/TestStatsUploadProvider.cs
+++ b/StatsDownload/StatsDownload.Core.Tests/TestStatsUploadProvider.cs
@@ -150,18 +150,15 @@
         }
 
         [Test]
-        public void UploadStatsFiles_WhenExceptionThrown_ResultUnexpectedException()
+        public void UploadStatsFiles_WhenExceptionThrown_ResultInvalidStatFileData()
         {
-            var exception = new Exception();
-            statsFileParserServiceMock.Parse(Arg.Any<string>()).Throws(exception);
+            statsFileParserServiceMock.Parse(Arg.Any<string>()).Throws(new Exception());
 
             StatsUploadResults actual = InvokeUploadStatsFiles();
 
             Assert.That(actual.UploadResults.ElementAt(0).DownloadId, Is.EqualTo(1));
             Assert.That(actual.UploadResults.ElementAt(0).FailedReason,
                 Is.EqualTo(FailedReason.UnexpectedException));
-            Assert.That(actual.UploadResults.ElementAt(0).Exception,
-                Is.EqualTo(exception));
         }
 
         [Test]

--- a/StatsDownload/StatsDownload.Core.Tests/TestStatsUploadProvider.cs
+++ b/StatsDownload/StatsDownload.Core.Tests/TestStatsUploadProvider.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Data.Common;
     using System.Linq;
     using Exceptions;
     using Implementations;
@@ -149,6 +150,18 @@
         }
 
         [Test]
+        public void UploadStatsFiles_WhenExceptionThrown_ResultInvalidStatFileData()
+        {
+            statsFileParserServiceMock.Parse(Arg.Any<string>()).Throws(new Exception());
+
+            StatsUploadResults actual = InvokeUploadStatsFiles();
+
+            Assert.That(actual.UploadResults.ElementAt(0).DownloadId, Is.EqualTo(1));
+            Assert.That(actual.UploadResults.ElementAt(0).FailedReason,
+                Is.EqualTo(FailedReason.UnexpectedException));
+        }
+
+        [Test]
         public void UploadStatsFiles_WhenExceptionThrown_ReturnsUnexpectedExceptionResult()
         {
             SetUpWhenExceptionThrown();
@@ -157,6 +170,19 @@
 
             Assert.That(actual.Success, Is.False);
             Assert.That(actual.FailedReason, Is.EqualTo(FailedReason.UnexpectedException));
+        }
+
+        [Test]
+        public void UploadStatsFiles_WhenExceptionThrown_RollsBackTransaction()
+        {
+            statsFileParserServiceMock.Parse(Arg.Any<string>()).Throws(new Exception());
+
+            var tranaction = Substitute.For<DbTransaction>();
+            statsUploadDatabaseServiceMock.StartStatsUpload(1).Returns(tranaction);
+
+            InvokeUploadStatsFiles();
+
+            statsUploadDatabaseServiceMock.Received().Rollback(tranaction);
         }
 
         [Test]
@@ -202,6 +228,19 @@
         }
 
         [Test]
+        public void UploadStatsFiles_WhenInvalidStatsFileExceptionThrown_RollsBackTransaction()
+        {
+            SetUpWhenInvalidStatsFileExceptionThrown();
+
+            var tranaction = Substitute.For<DbTransaction>();
+            statsUploadDatabaseServiceMock.StartStatsUpload(1).Returns(tranaction);
+
+            InvokeUploadStatsFiles();
+
+            statsUploadDatabaseServiceMock.Received().Rollback(tranaction);
+        }
+
+        [Test]
         public void UploadStatsFiles_WhenInvalidStatsFileExceptionThrown_UpdatesStatsUploadToError()
         {
             SetUpWhenInvalidStatsFileExceptionThrown();
@@ -214,18 +253,23 @@
         [Test]
         public void UploadStatsFiles_WhenInvoked_AddsUsersData()
         {
+            var tranaction1 = Substitute.For<DbTransaction>();
+            statsUploadDatabaseServiceMock.StartStatsUpload(1).Returns(tranaction1);
+            var tranaction2 = Substitute.For<DbTransaction>();
+            statsUploadDatabaseServiceMock.StartStatsUpload(2).Returns(tranaction2);
+
             InvokeUploadStatsFiles();
 
             Received.InOrder(() =>
             {
-                statsUploadDatabaseServiceMock.AddUsers(1,
-                    Arg.Is<IEnumerable<UserData>>((datas => datas.Contains(user1) && datas.Contains(user2))),
+                statsUploadDatabaseServiceMock.AddUsers(tranaction1, 1,
+                    Arg.Is<IEnumerable<UserData>>(datas => datas.Contains(user1) && datas.Contains(user2)),
                     Arg.Is<IEnumerable<FailedUserData>>(
-                        (data => data.Contains(failedUser1) && data.Contains(failedUser2))));
-                statsUploadDatabaseServiceMock.AddUsers(2,
-                    Arg.Is<IEnumerable<UserData>>((datas => datas.Contains(user3) && datas.Contains(user4))),
+                        data => data.Contains(failedUser1) && data.Contains(failedUser2)));
+                statsUploadDatabaseServiceMock.AddUsers(tranaction2, 2,
+                    Arg.Is<IEnumerable<UserData>>(datas => datas.Contains(user3) && datas.Contains(user4)),
                     Arg.Is<IEnumerable<FailedUserData>>(
-                        (data => data.Contains(failedUser3) && data.Contains(failedUser4))));
+                        data => data.Contains(failedUser3) && data.Contains(failedUser4)));
             });
         }
 
@@ -264,16 +308,23 @@
         [Test]
         public void UploadStatsFiles_WhenInvoked_UpdatesTheDownloadFileState()
         {
+            var tranaction1 = Substitute.For<DbTransaction>();
+            statsUploadDatabaseServiceMock.StartStatsUpload(1).Returns(tranaction1);
+            var tranaction2 = Substitute.For<DbTransaction>();
+            statsUploadDatabaseServiceMock.StartStatsUpload(2).Returns(tranaction2);
+
             InvokeUploadStatsFiles();
 
             Received.InOrder(() =>
             {
-                statsUploadDatabaseServiceMock.StartStatsUpload(1);
                 statsUploadDatabaseServiceMock.GetFileData(1);
-                statsUploadDatabaseServiceMock.StatsUploadFinished(1, downloadDateTime);
-                statsUploadDatabaseServiceMock.StartStatsUpload(2);
+                statsUploadDatabaseServiceMock.StartStatsUpload(1);
+                statsUploadDatabaseServiceMock.StatsUploadFinished(tranaction1, 1, downloadDateTime);
+                statsUploadDatabaseServiceMock.Commit(tranaction1);
                 statsUploadDatabaseServiceMock.GetFileData(2);
-                statsUploadDatabaseServiceMock.StatsUploadFinished(2, downloadDateTime);
+                statsUploadDatabaseServiceMock.StartStatsUpload(2);
+                statsUploadDatabaseServiceMock.StatsUploadFinished(tranaction2, 2, downloadDateTime);
+                statsUploadDatabaseServiceMock.Commit(tranaction2);
             });
         }
 

--- a/StatsDownload/StatsDownload.Core.Tests/TestStatsUploadProvider.cs
+++ b/StatsDownload/StatsDownload.Core.Tests/TestStatsUploadProvider.cs
@@ -150,15 +150,18 @@
         }
 
         [Test]
-        public void UploadStatsFiles_WhenExceptionThrown_ResultInvalidStatFileData()
+        public void UploadStatsFiles_WhenExceptionThrown_ResultUnexpectedException()
         {
-            statsFileParserServiceMock.Parse(Arg.Any<string>()).Throws(new Exception());
+            var exception = new Exception();
+            statsFileParserServiceMock.Parse(Arg.Any<string>()).Throws(exception);
 
             StatsUploadResults actual = InvokeUploadStatsFiles();
 
             Assert.That(actual.UploadResults.ElementAt(0).DownloadId, Is.EqualTo(1));
             Assert.That(actual.UploadResults.ElementAt(0).FailedReason,
                 Is.EqualTo(FailedReason.UnexpectedException));
+            Assert.That(actual.UploadResults.ElementAt(0).Exception,
+                Is.EqualTo(exception));
         }
 
         [Test]

--- a/StatsDownload/StatsDownload.Core.Tests/TestStatsUploadProvider.cs
+++ b/StatsDownload/StatsDownload.Core.Tests/TestStatsUploadProvider.cs
@@ -104,6 +104,18 @@
         }
 
         [Test]
+        public void UploadStatsFiles_WhenDatabaseTimeoutExceptionThrown_ReturnsDatabaseTimeoutResult()
+        {
+            SetUpWhenDatabaseTimeoutExceptionThrown();
+
+            StatsUploadResults actual = InvokeUploadStatsFiles();
+
+            Assert.That(actual.UploadResults.ElementAt(0).DownloadId, Is.EqualTo(1));
+            Assert.That(actual.UploadResults.ElementAt(0).FailedReason,
+                Is.EqualTo(FailedReason.StatsUploadTimeout));
+        }
+
+        [Test]
         public void UploadStatsFiles_WhenDataStoreIsNotAvailable_LogsResult()
         {
             SetUpWhenDataStoreIsNotAvailable();
@@ -371,6 +383,12 @@
                 statsUploadEmailService);
         }
 
+        private void SetUpWhenDatabaseTimeoutExceptionThrown()
+        {
+            var exception = new TestDbTimeoutException();
+            statsUploadDatabaseServiceMock.GetFileData(1).Throws(exception);
+        }
+
         private void SetUpWhenDataStoreIsNotAvailable()
         {
             statsUploadDatabaseServiceMock.IsAvailable().Returns(false);
@@ -387,6 +405,13 @@
         {
             var exception = new InvalidStatsFileException();
             statsFileParserServiceMock.Parse(Arg.Any<string>()).Throws(exception);
+        }
+
+        private class TestDbTimeoutException : DbException
+        {
+            public TestDbTimeoutException() : base("Mock timeout exception", -2146232060)
+            {
+            }
         }
     }
 }

--- a/StatsDownload/StatsDownload.Core.Tests/TestWhitespaceNameUsersFilter.cs
+++ b/StatsDownload/StatsDownload.Core.Tests/TestWhitespaceNameUsersFilter.cs
@@ -39,7 +39,7 @@
             var expected = new ParseResults(downloadDateTime, null, null);
             innerServiceMock.Parse("fileData").Returns(expected);
 
-            var actual = systemUnderTest.Parse("fileData");
+            ParseResults actual = systemUnderTest.Parse("fileData");
 
             Assert.That(actual, Is.EqualTo(expected));
         }

--- a/StatsDownload/StatsDownload.Core.Tests/TestZeroPointUsersFilter.cs
+++ b/StatsDownload/StatsDownload.Core.Tests/TestZeroPointUsersFilter.cs
@@ -39,7 +39,7 @@
             var expected = new ParseResults(downloadDateTime, null, null);
             innerServiceMock.Parse("fileData").Returns(expected);
 
-            var actual = systemUnderTest.Parse("fileData");
+            ParseResults actual = systemUnderTest.Parse("fileData");
 
             Assert.That(actual, Is.EqualTo(expected));
         }

--- a/StatsDownload/StatsDownload.Core/Constants.cs
+++ b/StatsDownload/StatsDownload.Core/Constants.cs
@@ -78,16 +78,16 @@
         {
             public const string ExpectedHeader = @"name	newcredit	sum(total)	team";
 
-            public static string[] StandardDateTimeFormats =
-            {
-                "ddd MMM  d HH:mm:ss PST yyyy",
-                "ddd MMM dd HH:mm:ss PST yyyy"
-            };
-
             public static string[] DaylightSavingsDateTimeFormats =
             {
                 "ddd MMM  d HH:mm:ss PDT yyyy",
                 "ddd MMM dd HH:mm:ss PDT yyyy"
+            };
+
+            public static string[] StandardDateTimeFormats =
+            {
+                "ddd MMM  d HH:mm:ss PST yyyy",
+                "ddd MMM dd HH:mm:ss PST yyyy"
             };
         }
     }

--- a/StatsDownload/StatsDownload.Core/Implementations/ErrorMessageProvider.cs
+++ b/StatsDownload/StatsDownload.Core/Implementations/ErrorMessageProvider.cs
@@ -63,6 +63,12 @@
                        + " The file failed validation; check the logs for more information. If this problem occurs again, then you should contact your technical advisor to review the logs and failed uploads.";
             }
 
+            if (failedReason == FailedReason.StatsUploadTimeout)
+            {
+                return StatsUploadFailBodyStart +
+                       " There was a timeout when uploading the stats and the file has been marked rejected. If a timeout occurs again, then you can try increasing the configurable command timeout.";
+            }
+
             if (failedReason == FailedReason.UnexpectedException)
             {
                 return FileDownloadFailBodyStart + " Check the log for more information.";

--- a/StatsDownload/StatsDownload.Core/Implementations/StatsUploadProvider.cs
+++ b/StatsDownload/StatsDownload.Core/Implementations/StatsUploadProvider.cs
@@ -118,9 +118,10 @@
             loggingService.LogVerbose(message);
         }
 
-        private StatsUploadResult NewFailedStatsUploadResult(int downloadId, FailedReason failedReason)
+        private StatsUploadResult NewFailedStatsUploadResult(int downloadId, FailedReason failedReason,
+            Exception exception)
         {
-            return new StatsUploadResult(downloadId, failedReason);
+            return new StatsUploadResult(downloadId, failedReason, exception);
         }
 
         private void UploadStatsFile(List<StatsUploadResult> statsUploadResults, int downloadId)
@@ -144,7 +145,8 @@
             {
                 statsUploadDatabaseService.Rollback(transaction);
                 FailedReason failedReason = GetFailedReason(exception);
-                StatsUploadResult failedStatsUploadResult = NewFailedStatsUploadResult(downloadId, failedReason);
+                StatsUploadResult failedStatsUploadResult =
+                    NewFailedStatsUploadResult(downloadId, failedReason, exception);
                 loggingService.LogResult(failedStatsUploadResult);
                 statsUploadEmailService.SendEmail(failedStatsUploadResult);
                 statsUploadDatabaseService.StatsUploadError(failedStatsUploadResult);

--- a/StatsDownload/StatsDownload.Core/Implementations/StatsUploadProvider.cs
+++ b/StatsDownload/StatsDownload.Core/Implementations/StatsUploadProvider.cs
@@ -118,10 +118,9 @@
             loggingService.LogVerbose(message);
         }
 
-        private StatsUploadResult NewFailedStatsUploadResult(int downloadId, FailedReason failedReason,
-            Exception exception)
+        private StatsUploadResult NewFailedStatsUploadResult(int downloadId, FailedReason failedReason)
         {
-            return new StatsUploadResult(downloadId, failedReason, exception);
+            return new StatsUploadResult(downloadId, failedReason);
         }
 
         private void UploadStatsFile(List<StatsUploadResult> statsUploadResults, int downloadId)
@@ -145,8 +144,7 @@
             {
                 statsUploadDatabaseService.Rollback(transaction);
                 FailedReason failedReason = GetFailedReason(exception);
-                StatsUploadResult failedStatsUploadResult =
-                    NewFailedStatsUploadResult(downloadId, failedReason, exception);
+                StatsUploadResult failedStatsUploadResult = NewFailedStatsUploadResult(downloadId, failedReason);
                 loggingService.LogResult(failedStatsUploadResult);
                 statsUploadEmailService.SendEmail(failedStatsUploadResult);
                 statsUploadDatabaseService.StatsUploadError(failedStatsUploadResult);

--- a/StatsDownload/StatsDownload.Core/Implementations/StatsUploadProvider.cs
+++ b/StatsDownload/StatsDownload.Core/Implementations/StatsUploadProvider.cs
@@ -94,6 +94,11 @@
                 return FailedReason.InvalidStatsFileUpload;
             }
 
+            if (exception is DbException dbException && dbException.ErrorCode == -2146232060)
+            {
+                return FailedReason.StatsUploadTimeout;
+            }
+
             return FailedReason.UnexpectedException;
         }
 

--- a/StatsDownload/StatsDownload.Core/Implementations/StatsUploadProvider.cs
+++ b/StatsDownload/StatsDownload.Core/Implementations/StatsUploadProvider.cs
@@ -146,6 +146,7 @@
                 FailedReason failedReason = GetFailedReason(exception);
                 StatsUploadResult failedStatsUploadResult = NewFailedStatsUploadResult(downloadId, failedReason);
                 loggingService.LogResult(failedStatsUploadResult);
+                loggingService.LogException(exception);
                 statsUploadEmailService.SendEmail(failedStatsUploadResult);
                 statsUploadDatabaseService.StatsUploadError(failedStatsUploadResult);
                 statsUploadResults.Add(failedStatsUploadResult);

--- a/StatsDownload/StatsDownload.Core/Wrappers/MicrosoftSqlDatabaseConnectionProvider.cs
+++ b/StatsDownload/StatsDownload.Core/Wrappers/MicrosoftSqlDatabaseConnectionProvider.cs
@@ -27,6 +27,11 @@
 
         public ConnectionState ConnectionState => sqlConnection.State;
 
+        public void Close()
+        {
+            sqlConnection.Close();
+        }
+
         public DbCommand CreateDbCommand()
         {
             DbCommand dbCommand = sqlConnection.CreateCommand();
@@ -98,6 +103,19 @@
             {
                 command.CommandText = storedProcedure;
                 command.CommandType = CommandType.StoredProcedure;
+                command.Parameters.AddRange(parameters?.ToArray() ?? new DbParameter[0]);
+                return command.ExecuteNonQuery();
+            }
+        }
+
+        public int ExecuteStoredProcedure(DbTransaction transaction, string storedProcedure,
+            IEnumerable<DbParameter> parameters)
+        {
+            using (DbCommand command = CreateDbCommand())
+            {
+                command.CommandText = storedProcedure;
+                command.CommandType = CommandType.StoredProcedure;
+                command.Transaction = transaction;
                 command.Parameters.AddRange(parameters?.ToArray() ?? new DbParameter[0]);
                 return command.ExecuteNonQuery();
             }

--- a/StatsDownload/StatsDownload.Core/Wrappers/MySqlDatabaseConnectionProvider.cs
+++ b/StatsDownload/StatsDownload.Core/Wrappers/MySqlDatabaseConnectionProvider.cs
@@ -35,6 +35,19 @@
             return dbCommand;
         }
 
+        public int ExecuteStoredProcedure(DbTransaction transaction, string storedProcedure,
+            IEnumerable<DbParameter> parameters)
+        {
+            using (DbCommand command = CreateDbCommand())
+            {
+                command.CommandText = storedProcedure;
+                command.CommandType = CommandType.StoredProcedure;
+                command.Transaction = transaction;
+                command.Parameters.AddRange(parameters?.ToArray() ?? new DbParameter[0]);
+                return command.ExecuteNonQuery();
+            }
+        }
+
         public DbTransaction CreateTransaction()
         {
             return sqlConnection.BeginTransaction();
@@ -112,6 +125,11 @@
         public void Open()
         {
             sqlConnection.Open();
+        }
+
+        public void Close()
+        {
+            sqlConnection.Close();
         }
 
         private void SetCommandTimeout(DbCommand dbCommand)

--- a/StatsDownload/StatsDownload.Core/Wrappers/Networking/WebClientWrapper.cs
+++ b/StatsDownload/StatsDownload.Core/Wrappers/Networking/WebClientWrapper.cs
@@ -18,14 +18,14 @@
 
         public Func<X509Certificate, X509Chain, SslPolicyErrors, bool> SslPolicyOverride
         {
-            get { return innerWebClient.SslPolicyOverride; }
-            set { innerWebClient.SslPolicyOverride = value; }
+            get => innerWebClient.SslPolicyOverride;
+            set => innerWebClient.SslPolicyOverride = value;
         }
 
         public TimeSpan Timeout
         {
-            get { return innerWebClient.Timeout; }
-            set { innerWebClient.Timeout = value; }
+            get => innerWebClient.Timeout;
+            set => innerWebClient.Timeout = value;
         }
 
         public void Dispose()

--- a/StatsDownload/StatsDownload.Email.Tests/TestEmailSettingsValidatorProvider.cs
+++ b/StatsDownload/StatsDownload.Email.Tests/TestEmailSettingsValidatorProvider.cs
@@ -19,7 +19,7 @@
         [TestCase(null)]
         public void ParseFromAddress_WhenInvalidFromAddress_ThrowsEmailArgumentException(string unsafeFromAddress)
         {
-            Assert.Throws<EmailArgumentException>((() => systemUnderTest.ParseFromAddress(unsafeFromAddress)));
+            Assert.Throws<EmailArgumentException>(() => systemUnderTest.ParseFromAddress(unsafeFromAddress));
         }
 
         [TestCase("user@domain.com")]
@@ -35,7 +35,7 @@
         public void ParseFromDisplayName_WhenInvalidFromDisplayName_ThrowsEmailArgumentException(
             string unsafeFromDisplayName)
         {
-            Assert.Throws<EmailArgumentException>((() => systemUnderTest.ParseFromDisplayName(unsafeFromDisplayName)));
+            Assert.Throws<EmailArgumentException>(() => systemUnderTest.ParseFromDisplayName(unsafeFromDisplayName));
         }
 
         [TestCase("Display Name")]
@@ -50,7 +50,7 @@
         [TestCase(null)]
         public void ParsePassword_WhenInvalidPassword_ThrowsEmailArgumentException(string unsafePassword)
         {
-            Assert.Throws<EmailArgumentException>((() => systemUnderTest.ParsePassword(unsafePassword)));
+            Assert.Throws<EmailArgumentException>(() => systemUnderTest.ParsePassword(unsafePassword));
         }
 
         [TestCase("password")]
@@ -90,7 +90,7 @@
         [TestCase("")]
         public void ParseReceivers_WhenInvokedWithInvalidReceiver_ThrowsEmailArgumentException(string unsafeReceivers)
         {
-            Assert.Throws<EmailArgumentException>((() => systemUnderTest.ParseReceivers(unsafeReceivers)));
+            Assert.Throws<EmailArgumentException>(() => systemUnderTest.ParseReceivers(unsafeReceivers));
         }
 
         [TestCase("user@domain.tld")]
@@ -118,7 +118,7 @@
         [TestCase(null)]
         public void ParseSmtpHost_WhenInvalidSmtpHost_ThrowsEmailArgumentException(string unsafeSmtpHost)
         {
-            Assert.Throws<EmailArgumentException>((() => systemUnderTest.ParseSmtpHost(unsafeSmtpHost)));
+            Assert.Throws<EmailArgumentException>(() => systemUnderTest.ParseSmtpHost(unsafeSmtpHost));
         }
 
         [TestCase("google.com")]

--- a/StatsDownload/StatsDownload.Email/EmailProvider.cs
+++ b/StatsDownload/StatsDownload.Email/EmailProvider.cs
@@ -48,15 +48,17 @@
 
             try
             {
+                sb.AppendLine("Attempting to send email:");
+                sb.AppendLine($"Subject: {subject}");
+                sb.Append($"Body: {body}");
+
                 MailAddress fromAddress = NewMailAddress();
 
                 IEnumerable<string> receivers = ParseReceivers(settingsService.GetReceivers());
 
                 using (SmtpClient smtpClient = NewSmtpClient(sb, fromAddress))
                 {
-                    sb.AppendLine("Sending email:");
-                    sb.AppendLine($"Subject: {subject}");
-                    sb.AppendLine($"Body: {body}");
+                    sb.AppendLine();
                     sb.AppendLine();
 
                     foreach (string address in receivers)

--- a/StatsDownload/StatsDownload.FileDownload.Console/App.config
+++ b/StatsDownload/StatsDownload.FileDownload.Console/App.config
@@ -6,7 +6,7 @@
   </startup>
   <connectionStrings>
     <add name="FoldingCoin"
-         connectionString="Server=(localdb)\MSSQLLocalDB;Database=FoldingCoin;Integrated Security=true;" />
+         connectionString="Server=(localdb)\MSSQLLocalDB;Database=FoldingCoin;Integrated Security=true;ConnectRetryCount=1;" />
   </connectionStrings>
   <appSettings>
     <!--Identify the database type 'MicrosoftSql' or 'MySql'; default is MicrosoftSql-->

--- a/StatsDownload/StatsDownload.FileDownload.Console/CastleWindsor/DatabaseFactoryComponentSelector.cs
+++ b/StatsDownload/StatsDownload.FileDownload.Console/CastleWindsor/DatabaseFactoryComponentSelector.cs
@@ -17,7 +17,7 @@
 
         protected override string GetComponentName(MethodInfo method, object[] arguments)
         {
-            var databaseType = settings.GetDatabaseType();
+            string databaseType = settings.GetDatabaseType();
             if (string.Equals(databaseType, "MySql", StringComparison.OrdinalIgnoreCase))
             {
                 return typeof (MySqlDatabaseConnectionProvider).FullName;

--- a/StatsDownload/StatsDownload.FileDownload.Console/CastleWindsor/WindsorContainer.cs
+++ b/StatsDownload/StatsDownload.FileDownload.Console/CastleWindsor/WindsorContainer.cs
@@ -6,9 +6,9 @@
 
     internal static class WindsorContainer
     {
-        private static readonly object sync = new object();
-
         private static IWindsorContainer innerContainer;
+
+        private static readonly object sync = new object();
 
         internal static IWindsorContainer Instance
         {
@@ -21,6 +21,13 @@
             }
         }
 
+        private static IWindsorContainer CreateWindsorContainer()
+        {
+            var container = new CastleWindsorContainer();
+            container.AddFacility<TypedFactoryFacility>();
+            return container;
+        }
+
         public static void Dispose()
         {
             lock (sync)
@@ -28,13 +35,6 @@
                 innerContainer?.Dispose();
                 innerContainer = null;
             }
-        }
-
-        private static IWindsorContainer CreateWindsorContainer()
-        {
-            var container = new CastleWindsorContainer();
-            container.AddFacility<TypedFactoryFacility>();
-            return container;
         }
     }
 }

--- a/StatsDownload/StatsDownload.FileServer.TestHarness/CastleWindsor/WindsorContainer.cs
+++ b/StatsDownload/StatsDownload.FileServer.TestHarness/CastleWindsor/WindsorContainer.cs
@@ -6,9 +6,9 @@
 
     internal static class WindsorContainer
     {
-        private static readonly object sync = new object();
-
         private static IWindsorContainer innerContainer;
+
+        private static readonly object sync = new object();
 
         internal static IWindsorContainer Instance
         {
@@ -21,6 +21,13 @@
             }
         }
 
+        private static IWindsorContainer CreateWindsorContainer()
+        {
+            var container = new CastleWindsorContainer();
+            container.AddFacility<WcfFacility>();
+            return container;
+        }
+
         public static void Dispose()
         {
             lock (sync)
@@ -28,13 +35,6 @@
                 innerContainer?.Dispose();
                 innerContainer = null;
             }
-        }
-
-        private static IWindsorContainer CreateWindsorContainer()
-        {
-            var container = new CastleWindsorContainer();
-            container.AddFacility<WcfFacility>();
-            return container;
         }
     }
 }

--- a/StatsDownload/StatsDownload.StatsUpload.Console/App.config
+++ b/StatsDownload/StatsDownload.StatsUpload.Console/App.config
@@ -6,7 +6,7 @@
   </startup>
   <connectionStrings>
     <add name="FoldingCoin"
-         connectionString="Server=(localdb)\MSSQLLocalDB;Database=FoldingCoin;Integrated Security=true;" />
+         connectionString="Server=(localdb)\MSSQLLocalDB;Database=FoldingCoin;Integrated Security=true;ConnectRetryCount=1;" />
   </connectionStrings>
   <appSettings>
     <!--Identify the database type 'MicrosoftSql' or 'MySql'; default is MicrosoftSql-->

--- a/StatsDownload/StatsDownload.StatsUpload.Console/CastleWindsor/DatabaseFactoryComponentSelector.cs
+++ b/StatsDownload/StatsDownload.StatsUpload.Console/CastleWindsor/DatabaseFactoryComponentSelector.cs
@@ -17,7 +17,7 @@
 
         protected override string GetComponentName(MethodInfo method, object[] arguments)
         {
-            var databaseType = settings.GetDatabaseType();
+            string databaseType = settings.GetDatabaseType();
             if (string.Equals(databaseType, "MySql", StringComparison.OrdinalIgnoreCase))
             {
                 return typeof (MySqlDatabaseConnectionProvider).FullName;

--- a/StatsDownload/StatsDownload.StatsUpload.Console/CastleWindsor/WindsorContainer.cs
+++ b/StatsDownload/StatsDownload.StatsUpload.Console/CastleWindsor/WindsorContainer.cs
@@ -6,9 +6,9 @@
 
     internal static class WindsorContainer
     {
-        private static readonly object sync = new object();
-
         private static IWindsorContainer innerContainer;
+
+        private static readonly object sync = new object();
 
         internal static IWindsorContainer Instance
         {
@@ -21,6 +21,13 @@
             }
         }
 
+        private static IWindsorContainer CreateWindsorContainer()
+        {
+            var container = new CastleWindsorContainer();
+            container.AddFacility<TypedFactoryFacility>();
+            return container;
+        }
+
         public static void Dispose()
         {
             lock (sync)
@@ -28,13 +35,6 @@
                 innerContainer?.Dispose();
                 innerContainer = null;
             }
-        }
-
-        private static IWindsorContainer CreateWindsorContainer()
-        {
-            var container = new CastleWindsorContainer();
-            container.AddFacility<TypedFactoryFacility>();
-            return container;
         }
     }
 }

--- a/StatsDownload/StatsDownload.TestHarness/App.config
+++ b/StatsDownload/StatsDownload.TestHarness/App.config
@@ -6,7 +6,7 @@
   </startup>
   <connectionStrings>
     <add name="FoldingCoin"
-         connectionString="Server=(localdb)\MSSQLLocalDB;Database=FoldingCoin;Integrated Security=true;" />
+         connectionString="Server=(localdb)\MSSQLLocalDB;Database=FoldingCoin;Integrated Security=true;ConnectRetryCount=1;" />
   </connectionStrings>
   <appSettings>
     <!--Identify the database type 'MicrosoftSql' or 'MySql'; default is MicrosoftSql-->
@@ -86,5 +86,9 @@
     <!--Test Harness Only Configuration-->
     <!--Enabling the one hundred users filter will filter out users after on hundred users-->
     <!--<add key="EnableOneHundredUsersFilter" value="true"/>-->
+
+    <!--Test Harness Only Configuration-->
+    <!--Enabling the sql exception during AddUsers test will throw a SQL exception after adding two users-->
+    <!--<add key="EnableSqlExceptionDuringAddUsersTest" value="true"/>-->
   </appSettings>
 </configuration>

--- a/StatsDownload/StatsDownload.TestHarness/CastleWindsor/DatabaseFactoryComponentSelector.cs
+++ b/StatsDownload/StatsDownload.TestHarness/CastleWindsor/DatabaseFactoryComponentSelector.cs
@@ -17,7 +17,7 @@
 
         protected override string GetComponentName(MethodInfo method, object[] arguments)
         {
-            var databaseType = settings.GetDatabaseType();
+            string databaseType = settings.GetDatabaseType();
             if (string.Equals(databaseType, "MySql", StringComparison.OrdinalIgnoreCase))
             {
                 return typeof (MySqlDatabaseConnectionProvider).FullName;

--- a/StatsDownload/StatsDownload.TestHarness/CastleWindsor/DependencyInstaller.cs
+++ b/StatsDownload/StatsDownload.TestHarness/CastleWindsor/DependencyInstaller.cs
@@ -21,13 +21,16 @@
             container.Register(Component.For<IApplicationLoggingService>().ImplementedBy<TestHarnessLoggingProvider>(),
                 Component
                     .For<IDatabaseConnectionSettingsService, IDownloadSettingsService, ITestHarnessSettingsService,
-                        IEmailSettingsService>().ImplementedBy<TestHarnessSettingsProvider>()
+                        IEmailSettingsService, ITestHarnessStatsDownloadSettings>()
+                    .ImplementedBy<TestHarnessSettingsProvider>()
                     .Forward<IZeroPointUsersFilterSettings, IGoogleUsersFilterSettings,
                         IWhitespaceNameUsersFilterSettings, INoPaymentAddressUsersFilterSettings>(),
                 Component.For<IFileDownloadMinimumWaitTimeService>()
                          .ImplementedBy<TestHarnessMinimumWaitTimeProvider>(),
                 Component.For<ISecureFilePayloadService>().ImplementedBy<TestHarnessSecureHttpFilePayloadProvider>(),
-                Component.For<IStatsFileParserService>().ImplementedBy<TestHarnessOneHundredUsersFilter>());
+                Component.For<IStatsFileParserService>().ImplementedBy<TestHarnessOneHundredUsersFilter>(),
+                Component.For<IFileDownloadDatabaseService, IStatsUploadDatabaseService>()
+                         .ImplementedBy<TestHarnessStatsDownloadDatabaseProvider>());
 
             container.Register(Component.For<IDateTimeService>().ImplementedBy<DateTimeProvider>(),
                 Component.For<IFileService>().ImplementedBy<FileProvider>(),
@@ -45,8 +48,9 @@
                 Component.For<ITypedFactoryComponentSelector>().ImplementedBy<DatabaseFactoryComponentSelector>(),
                 Component.For<IDatabaseConnectionServiceFactory>().AsFactory(selector =>
                     selector.SelectedWith<DatabaseFactoryComponentSelector>()),
-                Component.For<IFileDownloadDatabaseService, IStatsUploadDatabaseService>()
-                         .ImplementedBy<StatsDownloadDatabaseProvider>(),
+                Component
+                    .For<IFileDownloadDatabaseService, IStatsUploadDatabaseService, IStatsDownloadDatabaseService>()
+                    .ImplementedBy<StatsDownloadDatabaseProvider>(),
                 Component.For<ISecureFilePayloadService>().ImplementedBy<SecureFilePayloadProvider>(),
                 Component.For<IDownloadService>().ImplementedBy<SecureDownloadProvider>(),
                 Component.For<IDownloadService>().ImplementedBy<DownloadProvider>(),

--- a/StatsDownload/StatsDownload.TestHarness/CastleWindsor/WindsorContainer.cs
+++ b/StatsDownload/StatsDownload.TestHarness/CastleWindsor/WindsorContainer.cs
@@ -6,9 +6,9 @@
 
     internal static class WindsorContainer
     {
-        private static readonly object sync = new object();
-
         private static IWindsorContainer innerContainer;
+
+        private static readonly object sync = new object();
 
         internal static IWindsorContainer Instance
         {
@@ -21,6 +21,13 @@
             }
         }
 
+        private static IWindsorContainer CreateWindsorContainer()
+        {
+            var container = new CastleWindsorContainer();
+            container.AddFacility<TypedFactoryFacility>();
+            return container;
+        }
+
         public static void Dispose()
         {
             lock (sync)
@@ -28,13 +35,6 @@
                 innerContainer?.Dispose();
                 innerContainer = null;
             }
-        }
-
-        private static IWindsorContainer CreateWindsorContainer()
-        {
-            var container = new CastleWindsorContainer();
-            container.AddFacility<TypedFactoryFacility>();
-            return container;
         }
     }
 }

--- a/StatsDownload/StatsDownload.TestHarness/ITestHarnessStatsDownloadSettings.cs
+++ b/StatsDownload/StatsDownload.TestHarness/ITestHarnessStatsDownloadSettings.cs
@@ -1,0 +1,7 @@
+﻿namespace StatsDownload.TestHarness
+{
+    public interface ITestHarnessStatsDownloadSettings
+    {
+        bool Enabled { get; }
+    }
+}

--- a/StatsDownload/StatsDownload.TestHarness/MainForm.cs
+++ b/StatsDownload/StatsDownload.TestHarness/MainForm.cs
@@ -15,20 +15,6 @@
             WindsorContainer.Instance.Register(Component.For<Action<string>>().Instance(Log));
         }
 
-        internal void Log(string message)
-        {
-            if (LoggingTextBox.InvokeRequired)
-            {
-                LoggingTextBox.Invoke(new Action((() => Log(message))));
-            }
-            else
-            {
-                AppendToLog(message);
-                AppendToLog(Environment.NewLine);
-                AppendToLog(Environment.NewLine);
-            }
-        }
-
         private void AppendToLog(string message)
         {
             LoggingTextBox.AppendText(message);
@@ -69,6 +55,20 @@
             await
                 RunActionAsync(
                     () => { CreateFileDownloadServiceAndPerformAction(service => { service.DownloadStatsFile(); }); });
+        }
+
+        internal void Log(string message)
+        {
+            if (LoggingTextBox.InvokeRequired)
+            {
+                LoggingTextBox.Invoke(new Action(() => Log(message)));
+            }
+            else
+            {
+                AppendToLog(message);
+                AppendToLog(Environment.NewLine);
+                AppendToLog(Environment.NewLine);
+            }
         }
 
         private async Task RunActionAsync(Action action)

--- a/StatsDownload/StatsDownload.TestHarness/StatsDownload.TestHarness.csproj
+++ b/StatsDownload/StatsDownload.TestHarness/StatsDownload.TestHarness.csproj
@@ -73,6 +73,7 @@
     <Compile Include="CastleWindsor\DependencyRegistration.cs" />
     <Compile Include="CastleWindsor\DatabaseFactoryComponentSelector.cs" />
     <Compile Include="ITestHarnessSettingsService.cs" />
+    <Compile Include="ITestHarnessStatsDownloadSettings.cs" />
     <Compile Include="MainForm.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -87,6 +88,7 @@
     <Compile Include="TestHarnessSettingsProvider.cs" />
     <Compile Include="TestHarnessLoggingProvider.cs" />
     <Compile Include="TestHarnessOneHundredUsersFilter.cs" />
+    <Compile Include="TestHarnessStatsDownloadDatabaseProvider.cs" />
     <EmbeddedResource Include="MainForm.resx">
       <DependentUpon>MainForm.cs</DependentUpon>
     </EmbeddedResource>

--- a/StatsDownload/StatsDownload.TestHarness/TestHarnessSettingsProvider.cs
+++ b/StatsDownload/StatsDownload.TestHarness/TestHarnessSettingsProvider.cs
@@ -11,7 +11,7 @@
     /// </summary>
     public class TestHarnessSettingsProvider : IDatabaseConnectionSettingsService, IDownloadSettingsService,
         ITestHarnessSettingsService, IEmailSettingsService, IZeroPointUsersFilterSettings, IGoogleUsersFilterSettings,
-        IWhitespaceNameUsersFilterSettings, INoPaymentAddressUsersFilterSettings
+        IWhitespaceNameUsersFilterSettings, INoPaymentAddressUsersFilterSettings, ITestHarnessStatsDownloadSettings
     {
         public int? GetCommandTimeout()
         {
@@ -106,6 +106,8 @@
         {
             return GetBoolConfig("DisableSecureFilePayload");
         }
+
+        bool ITestHarnessStatsDownloadSettings.Enabled => GetBoolConfig("EnableSqlExceptionDuringAddUsersTest");
 
         bool IWhitespaceNameUsersFilterSettings.Enabled => GetBoolConfig("EnableWhitespaceNameUsersFilter");
 

--- a/StatsDownload/StatsDownload.TestHarness/TestHarnessStatsDownloadDatabaseProvider.cs
+++ b/StatsDownload/StatsDownload.TestHarness/TestHarnessStatsDownloadDatabaseProvider.cs
@@ -1,0 +1,108 @@
+﻿namespace StatsDownload.TestHarness
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Data.Common;
+    using System.Data.SqlTypes;
+    using System.Linq;
+    using Core.Interfaces;
+    using Core.Interfaces.DataTransfer;
+
+    public class TestHarnessStatsDownloadDatabaseProvider : IStatsDownloadDatabaseService
+    {
+        private readonly IStatsDownloadDatabaseService innerService;
+
+        private readonly ITestHarnessStatsDownloadSettings settings;
+
+        public TestHarnessStatsDownloadDatabaseProvider(IStatsDownloadDatabaseService innerService,
+            ITestHarnessStatsDownloadSettings settings)
+        {
+            this.innerService = innerService;
+            this.settings = settings;
+        }
+
+        public void Rollback(DbTransaction transaction)
+        {
+            innerService.Rollback(transaction);
+        }
+
+        public void Commit(DbTransaction transaction)
+        {
+            innerService.Commit(transaction);
+        }
+
+        public void FileDownloadError(FileDownloadResult fileDownloadResult)
+        {
+            innerService.FileDownloadError(fileDownloadResult);
+        }
+
+        public void FileDownloadFinished(FilePayload filePayload)
+        {
+            innerService.FileDownloadFinished(filePayload);
+        }
+
+        public DateTime GetLastFileDownloadDateTime()
+        {
+            return innerService.GetLastFileDownloadDateTime();
+        }
+
+        public bool IsAvailable()
+        {
+            return innerService.IsAvailable();
+        }
+
+        public void AddUsers(DbTransaction transaction, int downloadId, IEnumerable<UserData> usersData,
+            IEnumerable<FailedUserData> failedUsers)
+        {
+            innerService.AddUsers(transaction, downloadId, ModifiedUsers(usersData), failedUsers);
+        }
+
+        public IEnumerable<int> GetDownloadsReadyForUpload()
+        {
+            return innerService.GetDownloadsReadyForUpload();
+        }
+
+        public string GetFileData(int downloadId)
+        {
+            return innerService.GetFileData(downloadId);
+        }
+
+        public DbTransaction StartStatsUpload(int downloadId)
+        {
+            return innerService.StartStatsUpload(downloadId);
+        }
+
+        public void StatsUploadError(StatsUploadResult statsUploadResult)
+        {
+            innerService.StatsUploadError(statsUploadResult);
+        }
+
+        public void StatsUploadFinished(DbTransaction transaction, int downloadId, DateTime downloadDateTime)
+        {
+            innerService.StatsUploadFinished(transaction, downloadId, downloadDateTime);
+        }
+
+        public void NewFileDownloadStarted(FilePayload filePayload)
+        {
+            innerService.NewFileDownloadStarted(filePayload);
+        }
+
+        public void UpdateToLatest()
+        {
+            innerService.UpdateToLatest();
+        }
+
+        private IEnumerable<UserData> ModifiedUsers(IEnumerable<UserData> usersData)
+        {
+            for (var index = 0; index < usersData.Count(); index++)
+            {
+                if (settings.Enabled && index == 2)
+                {
+                    throw new SqlTypeException("Mocking an exception being thrown during the add users.");
+                }
+
+                yield return usersData.ElementAt(index);
+            }
+        }
+    }
+}

--- a/StatsDownload/StatsDownload.sln.DotSettings
+++ b/StatsDownload/StatsDownload.sln.DotSettings
@@ -79,7 +79,7 @@
       &lt;/Entry.SortBy&gt;&#xD;
     &lt;/Entry&gt;&#xD;
     &lt;Entry DisplayName="All other members" /&gt;&#xD;
-    &lt;Entry Priority="100" DisplayName="Test Methods"&gt;&#xD;
+    &lt;Entry DisplayName="Test Methods" Priority="100"&gt;&#xD;
       &lt;Entry.Match&gt;&#xD;
         &lt;And&gt;&#xD;
           &lt;Kind Is="Method" /&gt;&#xD;
@@ -119,7 +119,7 @@
         &lt;/And&gt;&#xD;
       &lt;/Entry.Match&gt;&#xD;
     &lt;/Entry&gt;&#xD;
-    &lt;Entry Priority="100" DisplayName="Test Methods"&gt;&#xD;
+    &lt;Entry DisplayName="Test Methods" Priority="100"&gt;&#xD;
       &lt;Entry.Match&gt;&#xD;
         &lt;And&gt;&#xD;
           &lt;Kind Is="Method" /&gt;&#xD;
@@ -136,7 +136,7 @@
     &lt;Entry DisplayName="All other members" /&gt;&#xD;
   &lt;/TypePattern&gt;&#xD;
   &lt;TypePattern DisplayName="Default Pattern"&gt;&#xD;
-    &lt;Entry Priority="100" DisplayName="Public Delegates"&gt;&#xD;
+    &lt;Entry DisplayName="Public Delegates" Priority="100"&gt;&#xD;
       &lt;Entry.Match&gt;&#xD;
         &lt;And&gt;&#xD;
           &lt;Access Is="Public" /&gt;&#xD;
@@ -147,7 +147,7 @@
         &lt;Name /&gt;&#xD;
       &lt;/Entry.SortBy&gt;&#xD;
     &lt;/Entry&gt;&#xD;
-    &lt;Entry Priority="100" DisplayName="Public Enums"&gt;&#xD;
+    &lt;Entry DisplayName="Public Enums" Priority="100"&gt;&#xD;
       &lt;Entry.Match&gt;&#xD;
         &lt;And&gt;&#xD;
           &lt;Access Is="Public" /&gt;&#xD;
@@ -169,7 +169,8 @@
         &lt;/Or&gt;&#xD;
       &lt;/Entry.Match&gt;&#xD;
       &lt;Entry.SortBy&gt;&#xD;
-        &lt;Kind Order="Constant Field" /&gt;&#xD;
+        &lt;Kind Is="Member" /&gt;&#xD;
+        &lt;Name /&gt;&#xD;
       &lt;/Entry.SortBy&gt;&#xD;
     &lt;/Entry&gt;&#xD;
     &lt;Entry DisplayName="Fields"&gt;&#xD;
@@ -192,6 +193,7 @@
       &lt;/Entry.Match&gt;&#xD;
       &lt;Entry.SortBy&gt;&#xD;
         &lt;Static /&gt;&#xD;
+        &lt;Name /&gt;&#xD;
       &lt;/Entry.SortBy&gt;&#xD;
     &lt;/Entry&gt;&#xD;
     &lt;Entry DisplayName="Properties, Indexers"&gt;&#xD;
@@ -201,8 +203,11 @@
           &lt;Kind Is="Indexer" /&gt;&#xD;
         &lt;/Or&gt;&#xD;
       &lt;/Entry.Match&gt;&#xD;
+      &lt;Entry.SortBy&gt;&#xD;
+        &lt;Name /&gt;&#xD;
+      &lt;/Entry.SortBy&gt;&#xD;
     &lt;/Entry&gt;&#xD;
-    &lt;Entry Priority="100" DisplayName="Interface Implementations"&gt;&#xD;
+    &lt;Entry DisplayName="Interface Implementations" Priority="100"&gt;&#xD;
       &lt;Entry.Match&gt;&#xD;
         &lt;And&gt;&#xD;
           &lt;Kind Is="Member" /&gt;&#xD;
@@ -213,11 +218,19 @@
         &lt;ImplementsInterface Immediate="True" /&gt;&#xD;
       &lt;/Entry.SortBy&gt;&#xD;
     &lt;/Entry&gt;&#xD;
-    &lt;Entry DisplayName="All other members" /&gt;&#xD;
+    &lt;Entry DisplayName="All other members"&gt;&#xD;
+      &lt;Entry.SortBy&gt;&#xD;
+        &lt;Access /&gt;&#xD;
+        &lt;Name /&gt;&#xD;
+      &lt;/Entry.SortBy&gt;&#xD;
+    &lt;/Entry&gt;&#xD;
     &lt;Entry DisplayName="Nested Types"&gt;&#xD;
       &lt;Entry.Match&gt;&#xD;
         &lt;Kind Is="Type" /&gt;&#xD;
       &lt;/Entry.Match&gt;&#xD;
+      &lt;Entry.SortBy&gt;&#xD;
+        &lt;Name /&gt;&#xD;
+      &lt;/Entry.SortBy&gt;&#xD;
     &lt;/Entry&gt;&#xD;
   &lt;/TypePattern&gt;&#xD;
 &lt;/Patterns&gt;</s:String>

--- a/StatsDownload/StatsDownload.sln.DotSettings
+++ b/StatsDownload/StatsDownload.sln.DotSettings
@@ -133,7 +133,12 @@
         &lt;Name /&gt;&#xD;
       &lt;/Entry.SortBy&gt;&#xD;
     &lt;/Entry&gt;&#xD;
-    &lt;Entry DisplayName="All other members" /&gt;&#xD;
+    &lt;Entry DisplayName="All other members"&gt;&#xD;
+      &lt;Entry.SortBy&gt;&#xD;
+        &lt;Name /&gt;&#xD;
+        &lt;Kind Is="Member" /&gt;&#xD;
+      &lt;/Entry.SortBy&gt;&#xD;
+    &lt;/Entry&gt;&#xD;
   &lt;/TypePattern&gt;&#xD;
   &lt;TypePattern DisplayName="Default Pattern"&gt;&#xD;
     &lt;Entry DisplayName="Public Delegates" Priority="100"&gt;&#xD;


### PR DESCRIPTION
Made it so that the exception would be logged when one is thrown during the stats upload process.
Updated the email provider to show the email subject and body (easier for testing to see message without having to setup a SMTP provider)
Added a new failed reason type to capture when a timeout occurs and give a useful message here